### PR TITLE
#3 feature: Use @Test annotation for test detection

### DIFF
--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/FunctionNode.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/FunctionNode.kt
@@ -1,0 +1,31 @@
+package io.github.mikhailhal.sonarkt.common
+
+/**
+ * 関数ノード
+ *
+ * グラフ内の関数を表すドメインモデル。
+ * FQNで同一性を判定するため、equals/hashCodeはfqnのみを使用。
+ *
+ * @property fqn 関数の完全修飾名
+ * @property isTest @Testアノテーションが付与されているか
+ */
+data class FunctionNode(
+    val fqn: FunctionFqn,
+    val isTest: Boolean
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is FunctionNode) return false
+        return fqn == other.fqn
+    }
+
+    override fun hashCode(): Int = fqn.hashCode()
+
+    companion object {
+        /**
+         * 検索用のダミーノードを作成
+         * isTestの値は検索には影響しない
+         */
+        fun forLookup(fqn: FunctionFqn): FunctionNode = FunctionNode(fqn, isTest = false)
+    }
+}

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolver.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolver.kt
@@ -8,7 +8,7 @@ import io.github.mikhailhal.sonarkt.common.FunctionFqn
  * アルゴリズム: 逆方向BFS
  * 1. 変更された関数(callee)をキューに入れる
  * 2. キューからcalleeを取り出し、calleeを呼んでいる関数(callers)を取得
- * 3. callerがテスト関数なら結果に追加
+ * 3. callerがテスト関数（@Test付き）なら結果に追加
  * 4. callerがテスト関数でなければキューに追加して更に遡る
  * 5. seenで重複訪問を防止
  *
@@ -53,7 +53,7 @@ class AffectedTestResolver(
      * @return 影響を受けるテスト関数のFQN集合
      */
     fun findAffectedTests(changedFunctions: Set<FunctionFqn>): Set<FunctionFqn> {
-        val affectedCaller = mutableSetOf<FunctionFqn>()
+        val affectedTests = mutableSetOf<FunctionFqn>()
         val seen = mutableSetOf<FunctionFqn>()
         val queue = ArrayDeque(changedFunctions)
 
@@ -70,47 +70,24 @@ class AffectedTestResolver(
             // callee(関数本体)を呼んでいる全関数を取得
             val callers = graph.getCallers(callee)
             for (caller in callers) {
-                if (isTestFunction(caller)) {
-                    affectedCaller.add(caller)
+                // @Testアノテーションが付与されている関数のみを影響テストとして追加
+                if (caller.isTest) {
+                    affectedTests.add(caller.fqn)
                 }
 
                 /**
                  * テスト関数であっても探索を継続する
-                 * 理由: テストコード内のヘルパー関数が他のテストから呼ばれるケース
+                 * 理由: @Test付きテスト関数が他のテストから呼ばれるケース
                  * 例:
-                 *   // test/TestUtils.kt
-                 *   class TestUtils {
-                 *       fun createMockUser(): User { ... }  // isTestFunction = true (TestUtilsクラス内)
-                 *   }
-                 *   // test/UserServiceTest.kt
-                 *   @Test fun testCreate() { createMockUser() }  // testCreate → createMockUser
-                 *   @Test fun testUpdate() { createMockUser() }  // testUpdate → createMockUser
-                 * createMockUser が変更された場合:
-                 *   1. createMockUser は TestUtils 内なので isTestFunction = true
-                 *   2. しかし実際は @Test ではないヘルパー関数
-                 *   3. 探索を続けないと testCreate, testUpdate を見つけられない
+                 *   @Test fun testA() { ... }
+                 *   @Test fun testB() { testA() }  // testBがtestAを呼ぶ
+                 *
+                 * testA が変更された場合、testB も影響を受ける。
+                 * よって、テスト関数でも探索を止めずに継続する。
                  */
-                queue.add(caller)
+                queue.add(caller.fqn)
             }
         }
-        return affectedCaller
-    }
-
-    /**
-     * 関数がテスト関数かどうかを判定
-     *
-     * TODO: 本来は @Test アノテーションの有無で判定すべき
-     * 現在は簡易的に関数名で判定（"test" で始まる or "Test" クラス内）
-     */
-    private fun isTestFunction(fqn: FunctionFqn): Boolean {
-        val functionName = fqn.substringAfterLast(".")
-        val className = fqn.substringBeforeLast(".", "")
-
-        return functionName.startsWith("test") ||
-               className.endsWith("Test") ||
-               className.endsWith("Tests") ||
-               className.endsWith("Spec") ||
-               className.endsWith("かどうか") ||
-               className.endsWith("テスト")
+        return affectedTests
     }
 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilder.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilder.kt
@@ -1,5 +1,6 @@
 package io.github.mikhailhal.sonarkt.processor
 
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -55,6 +56,8 @@ class GraphBuilder {
         }
 
         val callerFqn = callerFunction.fqName?.asString() ?: return
+        val callerIsTest = hasTestAnnotation(callerFunction)
+        val callerNode = FunctionNode(callerFqn, callerIsTest)
 
         // 2. callee を解決: Analysis API で関数シンボルを取得
         analyze(expression) {
@@ -64,9 +67,26 @@ class GraphBuilder {
             if (functionSymbol != null) {
                 val calleeFqn = functionSymbol.callableId?.asSingleFqName()?.asString()
                 if (calleeFqn != null) {
-                    graph.addEdge(callerFqn, calleeFqn)
+                    // calleeのisTestはここでは不明だが、検索キーとしてしか使わないのでfalseで良い
+                    val calleeNode = FunctionNode.forLookup(calleeFqn)
+                    graph.addEdge(callerNode, calleeNode)
                 }
             }
+        }
+    }
+
+    /**
+     * 関数に@Testアノテーションが付与されているかを判定
+     *
+     * 対応アノテーション:
+     * - org.junit.Test (JUnit 4)
+     * - org.junit.jupiter.api.Test (JUnit 5)
+     * - kotlin.test.Test (kotlin-test)
+     */
+    private fun hasTestAnnotation(function: KtNamedFunction): Boolean {
+        return function.annotationEntries.any { annotation ->
+            val shortName = annotation.shortName?.asString()
+            shortName == "Test"
         }
     }
 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraph.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraph.kt
@@ -1,6 +1,7 @@
 package io.github.mikhailhal.sonarkt.processor
 
 import io.github.mikhailhal.sonarkt.common.FunctionFqn
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 
 /**
  * 逆方向依存グラフ
@@ -11,30 +12,42 @@ import io.github.mikhailhal.sonarkt.common.FunctionFqn
  *
  * 例:
  *   Calculator.add が testAdd と helperB から呼ばれている場合:
- *   edges["Calculator.add"] = {"testAdd", "helperB"}
+ *   edges[Calculator.add] = {testAdd, helperB}
+ *
+ * FunctionNodeのequals/hashCodeはfqnのみで判定されるため、
+ * 検索時はFunctionNode.forLookup(fqn)で検索用ノードを作成できる。
  */
 class ReverseDependencyGraph {
-    private val edges: MutableMap<FunctionFqn, MutableSet<FunctionFqn>> = mutableMapOf()
+    private val edges: MutableMap<FunctionNode, MutableSet<FunctionNode>> = mutableMapOf()
 
     /**
      * caller が callee を呼んでいることを登録
      * 内部的には callee → caller の向きで保存される
      */
-    fun addEdge(caller: FunctionFqn, callee: FunctionFqn) {
+    fun addEdge(caller: FunctionNode, callee: FunctionNode) {
         edges.getOrPut(callee) { mutableSetOf() }.add(caller)
     }
 
     /**
      * callee を呼んでいる関数（caller）の一覧を取得
+     * FQN文字列で検索可能（FunctionNode.forLookupを内部で使用）
      */
-    fun getCallers(callee: FunctionFqn): Set<FunctionFqn> {
+    fun getCallers(callee: FunctionFqn): Set<FunctionNode> {
+        val lookupKey = FunctionNode.forLookup(callee)
+        return edges[lookupKey] ?: emptySet()
+    }
+
+    /**
+     * callee を呼んでいる関数（caller）の一覧を取得
+     */
+    fun getCallers(callee: FunctionNode): Set<FunctionNode> {
         return edges[callee] ?: emptySet()
     }
 
     /**
      * グラフの全エントリを取得（デバッグ用）
      */
-    fun getAllEdges(): Map<FunctionFqn, Set<FunctionFqn>> {
+    fun getAllEdges(): Map<FunctionNode, Set<FunctionNode>> {
         return edges.mapValues { it.value.toSet() }
     }
 

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolverTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolverTest.kt
@@ -1,17 +1,22 @@
 package io.github.mikhailhal.sonarkt.processor
 
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class AffectedTestResolverTest {
 
+    // Helper to create nodes
+    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, isTest)
+    private fun testNode(fqn: String) = FunctionNode(fqn, isTest = true)
+
     // === Basic detection ===
 
     @Test
     fun `direct caller is test function`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTest.testAdd", "com.example.Calculator.add")
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
@@ -23,8 +28,8 @@ class AffectedTestResolverTest {
     fun `transitive detection through helper`() {
         // testHelper -> helperB -> Calculator.add
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.helperB", "com.example.Calculator.add")
-        graph.addEdge("com.example.CalculatorTest.testHelper", "com.example.helperB")
+        graph.addEdge(node("com.example.helperB"), node("com.example.Calculator.add"))
+        graph.addEdge(testNode("com.example.CalculatorTest.testHelper"), node("com.example.helperB"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
@@ -35,8 +40,8 @@ class AffectedTestResolverTest {
     @Test
     fun `multiple tests affected`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTest.testAdd", "com.example.Calculator.add")
-        graph.addEdge("com.example.CalculatorTest.testAddNegative", "com.example.Calculator.add")
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
+        graph.addEdge(testNode("com.example.CalculatorTest.testAddNegative"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
@@ -53,8 +58,8 @@ class AffectedTestResolverTest {
     @Test
     fun `multiple changed functions`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTest.testAdd", "com.example.Calculator.add")
-        graph.addEdge("com.example.CalculatorTest.testMultiply", "com.example.Calculator.multiply")
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
+        graph.addEdge(testNode("com.example.CalculatorTest.testMultiply"), node("com.example.Calculator.multiply"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(
@@ -75,8 +80,8 @@ class AffectedTestResolverTest {
         // testA -> testB -> changed
         // Both should be detected because testA might call testB with different args
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.SomeTest.testB", "com.example.changed")
-        graph.addEdge("com.example.SomeTest.testA", "com.example.SomeTest.testB")
+        graph.addEdge(testNode("com.example.SomeTest.testB"), node("com.example.changed"))
+        graph.addEdge(testNode("com.example.SomeTest.testA"), testNode("com.example.SomeTest.testB"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.changed"))
@@ -95,7 +100,7 @@ class AffectedTestResolverTest {
     @Test
     fun `empty changed functions returns empty set`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTest.testAdd", "com.example.Calculator.add")
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(emptySet())
@@ -117,10 +122,10 @@ class AffectedTestResolverTest {
     fun `cycle in graph does not cause infinite loop`() {
         // a -> b -> c -> a (cycle)
         val graph = ReverseDependencyGraph()
-        graph.addEdge("b", "a")
-        graph.addEdge("c", "b")
-        graph.addEdge("a", "c")
-        graph.addEdge("com.example.SomeTest.testA", "a")
+        graph.addEdge(node("b"), node("a"))
+        graph.addEdge(node("c"), node("b"))
+        graph.addEdge(node("a"), node("c"))
+        graph.addEdge(testNode("com.example.SomeTest.testA"), node("a"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("a"))
@@ -129,12 +134,12 @@ class AffectedTestResolverTest {
         assertEquals(setOf("com.example.SomeTest.testA"), affected)
     }
 
-    // === isTestFunction detection ===
+    // === @Test annotation detection ===
 
     @Test
-    fun `function name starting with test is detected`() {
+    fun `function with isTest true is detected`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.Helper.testSomething", "com.example.foo")
+        graph.addEdge(testNode("com.example.Helper.testSomething"), node("com.example.foo"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.foo"))
@@ -143,46 +148,39 @@ class AffectedTestResolverTest {
     }
 
     @Test
-    fun `class ending with Test is detected`() {
+    fun `function with isTest false is not in result`() {
         val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTest.add", "com.example.foo")
-
-        val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.foo"))
-
-        assertEquals(setOf("com.example.CalculatorTest.add"), affected)
-    }
-
-    @Test
-    fun `class ending with Tests is detected`() {
-        val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorTests.add", "com.example.foo")
-
-        val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.foo"))
-
-        assertEquals(setOf("com.example.CalculatorTests.add"), affected)
-    }
-
-    @Test
-    fun `class ending with Spec is detected`() {
-        val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.CalculatorSpec.add", "com.example.foo")
-
-        val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.foo"))
-
-        assertEquals(setOf("com.example.CalculatorSpec.add"), affected)
-    }
-
-    @Test
-    fun `non-test function is not in result`() {
-        val graph = ReverseDependencyGraph()
-        graph.addEdge("com.example.Helper.doSomething", "com.example.foo")
+        graph.addEdge(node("com.example.Helper.doSomething"), node("com.example.foo"))
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(setOf("com.example.foo"))
 
         assertTrue(affected.isEmpty())
+    }
+
+    @Test
+    fun `mixed test and non-test callers`() {
+        val graph = ReverseDependencyGraph()
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
+        graph.addEdge(node("com.example.Helper.helper"), node("com.example.Calculator.add"))
+
+        val resolver = AffectedTestResolver(graph)
+        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+
+        // Only the test function should be in result
+        assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
+    }
+
+    @Test
+    fun `helper function leads to test`() {
+        // testAdd -> helper -> Calculator.add
+        val graph = ReverseDependencyGraph()
+        graph.addEdge(node("com.example.Helper.helper"), node("com.example.Calculator.add"))
+        graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Helper.helper"))
+
+        val resolver = AffectedTestResolver(graph)
+        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+
+        assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
     }
 }

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilderTest.kt
@@ -44,12 +44,20 @@ class GraphBuilderTest {
 
             // Calculator.add は CalculatorTest.testAdd と helperB から呼ばれる
             val addCallers = graph.getCallers("io.github.mikhailhal.sonarkt.Calculator.add")
-            assertTrue(addCallers.contains("io.github.mikhailhal.sonarkt.CalculatorTest.testAdd"))
-            assertTrue(addCallers.contains("io.github.mikhailhal.sonarkt.helperB"))
+            assertTrue(addCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.CalculatorTest.testAdd" })
+            assertTrue(addCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.helperB" })
 
             // helperB は CalculatorTest.testHelper から呼ばれる
             val helperBCallers = graph.getCallers("io.github.mikhailhal.sonarkt.helperB")
-            assertTrue(helperBCallers.contains("io.github.mikhailhal.sonarkt.CalculatorTest.testHelper"))
+            assertTrue(helperBCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.CalculatorTest.testHelper" })
+
+            // @Test annotation detection: testAdd should have isTest = true
+            val testAddCaller = addCallers.find { it.fqn == "io.github.mikhailhal.sonarkt.CalculatorTest.testAdd" }
+            assertTrue(testAddCaller?.isTest == true, "testAdd should have @Test annotation")
+
+            // helperB should have isTest = false (no @Test annotation)
+            val helperBCaller = addCallers.find { it.fqn == "io.github.mikhailhal.sonarkt.helperB" }
+            assertTrue(helperBCaller?.isTest == false, "helperB should not have @Test annotation")
 
         } finally {
             Disposer.dispose(projectDisposable)

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraphTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraphTest.kt
@@ -1,10 +1,15 @@
 package io.github.mikhailhal.sonarkt.processor
 
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class ReverseDependencyGraphTest {
+
+    // Helper to create test nodes
+    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, isTest)
+    private fun testNode(fqn: String) = FunctionNode(fqn, isTest = true)
 
     // === addEdge / getCallers ===
 
@@ -12,32 +17,37 @@ class ReverseDependencyGraphTest {
     fun `addEdge stores caller for callee`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("testAdd", "Calculator.add")
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
 
         val callers = graph.getCallers("Calculator.add")
-        assertEquals(setOf("testAdd"), callers)
+        assertEquals(1, callers.size)
+        assertTrue(callers.any { it.fqn == "testAdd" })
     }
 
     @Test
     fun `multiple callers for same callee`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("testAdd", "Calculator.add")
-        graph.addEdge("helperB", "Calculator.add")
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
+        graph.addEdge(node("helperB"), node("Calculator.add"))
 
         val callers = graph.getCallers("Calculator.add")
-        assertEquals(setOf("testAdd", "helperB"), callers)
+        assertEquals(2, callers.size)
+        assertTrue(callers.any { it.fqn == "testAdd" })
+        assertTrue(callers.any { it.fqn == "helperB" })
     }
 
     @Test
     fun `same caller calling multiple callees`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("main", "foo")
-        graph.addEdge("main", "bar")
+        graph.addEdge(node("main"), node("foo"))
+        graph.addEdge(node("main"), node("bar"))
 
-        assertEquals(setOf("main"), graph.getCallers("foo"))
-        assertEquals(setOf("main"), graph.getCallers("bar"))
+        assertEquals(1, graph.getCallers("foo").size)
+        assertEquals(1, graph.getCallers("bar").size)
+        assertTrue(graph.getCallers("foo").any { it.fqn == "main" })
+        assertTrue(graph.getCallers("bar").any { it.fqn == "main" })
     }
 
     @Test
@@ -52,12 +62,11 @@ class ReverseDependencyGraphTest {
     fun `duplicate addEdge is idempotent`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("testAdd", "Calculator.add")
-        graph.addEdge("testAdd", "Calculator.add")
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
 
         val callers = graph.getCallers("Calculator.add")
         assertEquals(1, callers.size)
-        assertEquals(setOf("testAdd"), callers)
     }
 
     // === getAllEdges ===
@@ -66,15 +75,13 @@ class ReverseDependencyGraphTest {
     fun `getAllEdges returns all edges`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("testAdd", "Calculator.add")
-        graph.addEdge("helperB", "Calculator.add")
-        graph.addEdge("testHelper", "helperB")
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
+        graph.addEdge(node("helperB"), node("Calculator.add"))
+        graph.addEdge(testNode("testHelper"), node("helperB"))
 
         val allEdges = graph.getAllEdges()
 
         assertEquals(2, allEdges.size)
-        assertEquals(setOf("testAdd", "helperB"), allEdges["Calculator.add"])
-        assertEquals(setOf("testHelper"), allEdges["helperB"])
     }
 
     @Test
@@ -91,9 +98,9 @@ class ReverseDependencyGraphTest {
     fun `stats returns correct counts`() {
         val graph = ReverseDependencyGraph()
 
-        graph.addEdge("testAdd", "Calculator.add")
-        graph.addEdge("helperB", "Calculator.add")
-        graph.addEdge("testHelper", "helperB")
+        graph.addEdge(testNode("testAdd"), node("Calculator.add"))
+        graph.addEdge(node("helperB"), node("Calculator.add"))
+        graph.addEdge(testNode("testHelper"), node("helperB"))
 
         val stats = graph.stats()
 
@@ -107,5 +114,23 @@ class ReverseDependencyGraphTest {
 
         val stats = graph.stats()
         assertEquals("Callees: 0, Total edges: 0", stats)
+    }
+
+    // === FunctionNode isTest property ===
+
+    @Test
+    fun `caller isTest is preserved in getCallers result`() {
+        val graph = ReverseDependencyGraph()
+
+        graph.addEdge(testNode("CalculatorTest.testAdd"), node("Calculator.add"))
+        graph.addEdge(node("Helper.helperB"), node("Calculator.add"))
+
+        val callers = graph.getCallers("Calculator.add")
+
+        val testCaller = callers.find { it.fqn == "CalculatorTest.testAdd" }
+        val helperCaller = callers.find { it.fqn == "Helper.helperB" }
+
+        assertEquals(true, testCaller?.isTest)
+        assertEquals(false, helperCaller?.isTest)
     }
 }

--- a/core/src/test/resources/sandbox/CalculatorTest.kt
+++ b/core/src/test/resources/sandbox/CalculatorTest.kt
@@ -1,17 +1,18 @@
 package io.github.mikhailhal.sonarkt
 
+import kotlin.test.Test
+
 /**
  * テストコードを模擬
- * 本来は src/test に置くが、PoCのため src/main に配置
  */
 class CalculatorTest {
-    // @Test (実際のアノテーションは省略)
+    @Test
     fun testAdd() {
         val calc = Calculator()
         calc.add(1, 2)
     }
 
-    // @Test
+    @Test
     fun testHelper() {
         helperB()
     }


### PR DESCRIPTION
- Add FunctionNode data class with fqn and isTest properties
  - equals/hashCode based on fqn only for map key lookups
- Update ReverseDependencyGraph to use FunctionNode
- Update GraphBuilder to detect @Test annotation via PSI
- Update AffectedTestResolver to use FunctionNode.isTest
- Remove legacy isTestFunction() pattern matching
- Update all related tests

Closes #3