### PR TITLE
#5 feat: Add multi-module support

### DIFF
--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/Main.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/Main.kt
@@ -2,6 +2,7 @@ package io.github.mikhailhal.sonarkt
 
 import com.intellij.openapi.util.Disposer
 import io.github.mikhailhal.sonarkt.collector.ChangedFunctionCollector
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import io.github.mikhailhal.sonarkt.emitter.AffectedTestEmitter
 import io.github.mikhailhal.sonarkt.processor.AffectedTestResolver
 import io.github.mikhailhal.sonarkt.processor.GraphBuilder
@@ -11,6 +12,9 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Paths
 import kotlin.system.exitProcess
+
+// シングルモジュール用のデフォルトモジュール名
+private const val DEFAULT_MODULE: ModuleName = "main"
 
 /**
  * sonar-kt CLI エントリーポイント
@@ -33,8 +37,9 @@ fun main(args: Array<String>) {
     val projectDisposable = Disposer.newDisposable("sonar-kt")
 
     try {
-        val ktFiles = loadKtFiles(projectPath, projectDisposable)
-        val output = runPipeline(diff, ktFiles)
+        val moduleFiles = loadKtFiles(projectPath, projectDisposable)
+        val modulePathMapping = mapOf(DEFAULT_MODULE to projectPath)
+        val output = runPipeline(diff, moduleFiles, modulePathMapping)
 
         if (output.isNotEmpty()) {
             println(output)
@@ -68,13 +73,16 @@ private fun readDiffFromStdin(): String {
 /**
  * プロジェクトからKtFileを読み込む
  */
-private fun loadKtFiles(projectPath: String, disposable: com.intellij.openapi.Disposable): List<KtFile> {
+private fun loadKtFiles(
+    projectPath: String,
+    disposable: com.intellij.openapi.Disposable
+): Map<ModuleName, List<KtFile>> {
     val session = buildStandaloneAnalysisAPISession(disposable) {
         buildKtModuleProvider {
             platform = JvmPlatforms.defaultJvmPlatform
 
             addModule(buildKtSourceModule {
-                moduleName = "main"
+                moduleName = DEFAULT_MODULE
                 platform = JvmPlatforms.defaultJvmPlatform
                 addSourceRoot(Paths.get(projectPath))
             })
@@ -82,16 +90,21 @@ private fun loadKtFiles(projectPath: String, disposable: com.intellij.openapi.Di
     }
 
     return session.modulesWithFiles
-        .flatMap { it.value }
-        .filterIsInstance<KtFile>()
+        .mapKeys { (kaModule, _) -> kaModule.name }
+        .mapValues { (_, files) -> files.filterIsInstance<KtFile>() }
 }
 
 /**
  * パイプライン実行
  */
-private fun runPipeline(diff: String, ktFiles: List<KtFile>): String {
-    val changedFunctions = ChangedFunctionCollector().collect(diff, ktFiles)
-    val graph = GraphBuilder().build(ktFiles)
+private fun runPipeline(
+    diff: String,
+    moduleFiles: Map<ModuleName, List<KtFile>>,
+    modulePathMapping: Map<ModuleName, String>
+): String {
+    val allKtFiles = moduleFiles.values.flatten()
+    val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
+    val graph = GraphBuilder().build(moduleFiles)
     val affectedTests = AffectedTestResolver(graph).findAffectedTests(changedFunctions)
     return AffectedTestEmitter.emit(affectedTests)
 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/SonarKt.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/SonarKt.kt
@@ -2,6 +2,7 @@ package io.github.mikhailhal.sonarkt
 
 import com.intellij.openapi.util.Disposer
 import io.github.mikhailhal.sonarkt.collector.ChangedFunctionCollector
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import io.github.mikhailhal.sonarkt.emitter.AffectedTestEmitter
 import io.github.mikhailhal.sonarkt.processor.AffectedTestResolver
 import io.github.mikhailhal.sonarkt.processor.GraphBuilder
@@ -14,38 +15,50 @@ import java.nio.file.Path
 /**
  * sonar-kt のメインAPI
  *
- * 使い方:
+ * マルチモジュールプロジェクト対応版:
  * ```
  * val affected = SonarKt.findAffectedTests(
  *     diff = "git diff output...",
- *     sourceRoots = listOf(Path.of("src/main/kotlin"), Path.of("src/test/kotlin"))
+ *     moduleSourceRoots = mapOf(
+ *         ":core" to listOf(Path.of("core/src/main/kotlin"), Path.of("core/src/test/kotlin")),
+ *         ":plugin" to listOf(Path.of("plugin/src/main/kotlin"), Path.of("plugin/src/test/kotlin"))
+ *     ),
+ *     modulePathMapping = mapOf(":core" to "core", ":plugin" to "plugin")
  * )
  * ```
  */
 object SonarKt {
 
     /**
-     * 変更されたコードに影響を受けるテストのFQN一覧を返す
+     * 変更されたコードに影響を受けるテストのFQN一覧を返す（マルチモジュール対応）
      *
      * @param diff git diff --unified=0 の出力
-     * @param sourceRoots Kotlinソースのルートディレクトリ
+     * @param moduleSourceRoots モジュール名 → ソースルートリストのマッピング
+     * @param modulePathMapping モジュール名 → モジュールルートパスのマッピング（diff解析用）
      * @return 影響テストのFQN集合
      */
-    fun findAffectedTests(diff: String, sourceRoots: List<Path>): Set<String> {
-        if (diff.isEmpty() || sourceRoots.isEmpty()) {
+    fun findAffectedTests(
+        diff: String,
+        moduleSourceRoots: Map<ModuleName, List<Path>>,
+        modulePathMapping: Map<ModuleName, String>
+    ): Set<String> {
+        if (diff.isEmpty() || moduleSourceRoots.isEmpty()) {
             return emptySet()
         }
 
         val projectDisposable = Disposer.newDisposable("sonar-kt")
 
         try {
-            val ktFiles = extractKtFilesViaSession(sourceRoots, projectDisposable)
-            if (ktFiles.isEmpty()) {
+            val moduleFiles = extractKtFilesViaSession(moduleSourceRoots, projectDisposable)
+            if (moduleFiles.values.all { it.isEmpty() }) {
                 return emptySet()
             }
 
-            val changedFunctions = ChangedFunctionCollector().collect(diff, ktFiles)
-            val graph = GraphBuilder().build(ktFiles)
+            // ChangedFunctionCollectorは全ファイルをフラットに受け取る
+            val allKtFiles = moduleFiles.values.flatten()
+            val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
+
+            val graph = GraphBuilder().build(moduleFiles)
             return AffectedTestResolver(graph).findAffectedTests(changedFunctions)
         } finally {
             Disposer.dispose(projectDisposable)
@@ -53,29 +66,43 @@ object SonarKt {
     }
 
     /**
-     * 影響テストを改行区切りの文字列で返す
+     * 影響テストを改行区切りの文字列で返す（マルチモジュール対応）
      */
-    fun findAffectedTestsAsString(diff: String, sourceRoots: List<Path>): String {
-        val affected = findAffectedTests(diff, sourceRoots)
+    fun findAffectedTestsAsString(
+        diff: String,
+        moduleSourceRoots: Map<ModuleName, List<Path>>,
+        modulePathMapping: Map<ModuleName, String>
+    ): String {
+        val affected = findAffectedTests(diff, moduleSourceRoots, modulePathMapping)
         return AffectedTestEmitter.emit(affected)
     }
 
-    private fun extractKtFilesViaSession(sourceRoots: List<Path>, disposable: com.intellij.openapi.Disposable): List<KtFile> {
+    /**
+     * 各モジュールからKtFileを抽出
+     *
+     * @return モジュール名 → KtFileリストのマッピング
+     */
+    private fun extractKtFilesViaSession(
+        moduleSourceRoots: Map<ModuleName, List<Path>>,
+        disposable: com.intellij.openapi.Disposable
+    ): Map<ModuleName, List<KtFile>> {
         val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
                 platform = JvmPlatforms.defaultJvmPlatform
 
-                addModule(buildKtSourceModule {
-                    moduleName = "project"
-                    platform = JvmPlatforms.defaultJvmPlatform
-                    sourceRoots.forEach { addSourceRoot(it) }
-                })
+                for ((moduleName, sourceRoots) in moduleSourceRoots) {
+                    addModule(buildKtSourceModule {
+                        this.moduleName = moduleName
+                        platform = JvmPlatforms.defaultJvmPlatform
+                        sourceRoots.forEach { addSourceRoot(it) }
+                    })
+                }
             }
         }
 
-        // モジュールに紐づいたファイル一覧からKtFileのみ抽出して返却
+        // KaSourceModule.name でモジュール名を取得し、KtFileをグループ化
         return session.modulesWithFiles
-            .flatMap { it.value }
-            .filterIsInstance<KtFile>()
+            .mapKeys { (kaModule, _) -> kaModule.name }
+            .mapValues { (_, files) -> files.filterIsInstance<KtFile>() }
     }
 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunction.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunction.kt
@@ -1,0 +1,19 @@
+package io.github.mikhailhal.sonarkt.collector
+
+import io.github.mikhailhal.sonarkt.common.FunctionFqn
+import io.github.mikhailhal.sonarkt.common.ModuleName
+
+/**
+ * 変更された関数を表すドメインモデル
+ *
+ * git diffから検出された変更関数の情報を保持する。
+ * マルチモジュール環境では同じFQNが複数モジュールに存在しうるため、
+ * モジュール名も含めて一意に識別する。
+ *
+ * @property fqn 関数の完全修飾名
+ * @property moduleName 関数が属するモジュール名
+ */
+data class ChangedFunction(
+    val fqn: FunctionFqn,
+    val moduleName: ModuleName
+)

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollector.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollector.kt
@@ -2,7 +2,7 @@ package io.github.mikhailhal.sonarkt.collector
 
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiDocumentManager
-import io.github.mikhailhal.sonarkt.common.FunctionFqn
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
@@ -20,15 +20,21 @@ import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 class ChangedFunctionCollector {
 
     /**
-     * 変更された関数のFQNを収集
+     * 変更された関数を収集
      *
      * @param diffOutput git diff --unified=0 の出力
      * @param ktFiles 解析対象のKtFileリスト
-     * @return 変更された関数のFQN集合
+     * @param modulePathMapping モジュール名 → モジュールルートパスのマッピング
+     *                         例: mapOf(":core" to "core", ":plugin" to "plugin")
+     * @return 変更された関数の集合
      */
-    fun collect(diffOutput: String, ktFiles: List<KtFile>): Set<FunctionFqn> {
+    fun collect(
+        diffOutput: String,
+        ktFiles: List<KtFile>,
+        modulePathMapping: Map<ModuleName, String>
+    ): Set<ChangedFunction> {
         val fileDiffs = GitDiffParser.parseKotlinFiles(diffOutput)
-        val changedFunctions = mutableSetOf<FunctionFqn>()
+        val changedFunctions = mutableSetOf<ChangedFunction>()
 
         if (fileDiffs.isEmpty()) return emptySet()
 
@@ -39,8 +45,11 @@ class ChangedFunctionCollector {
 
             val fileDiff = fileDiffs[relativePath] ?: continue
 
+            // ファイルパスからモジュール名を解決
+            val moduleName = resolveModuleName(relativePath, modulePathMapping)
+
             // このファイルの変更された関数を収集
-            val functions = collectChangedFunctionsInFile(ktFile, fileDiff)
+            val functions = collectChangedFunctionsInFile(ktFile, fileDiff, moduleName)
             changedFunctions.addAll(functions)
         }
 
@@ -48,13 +57,41 @@ class ChangedFunctionCollector {
     }
 
     /**
+     * ファイルパスからモジュール名を解決
+     *
+     * 最長プレフィックスマッチングでモジュールを特定する。
+     * 例: "core/src/main/kotlin/Foo.kt" → ":core"
+     *
+     * @param filePath リポジトリルートからの相対パス
+     * @param modulePathMapping モジュール名 → モジュールルートパスのマッピング
+     * @return 該当するモジュール名、見つからない場合は空文字列
+     */
+    private fun resolveModuleName(
+        filePath: String,
+        modulePathMapping: Map<ModuleName, String>
+    ): ModuleName {
+        var bestMatch: ModuleName = ""
+        var bestMatchLength = 0
+
+        for ((moduleName, modulePath) in modulePathMapping) {
+            if (filePath.startsWith(modulePath) && modulePath.length > bestMatchLength) {
+                bestMatch = moduleName
+                bestMatchLength = modulePath.length
+            }
+        }
+
+        return bestMatch
+    }
+
+    /**
      * 単一ファイル内の変更された関数を収集
      */
     private fun collectChangedFunctionsInFile(
         ktFile: KtFile,
-        fileDiff: FileDiff
-    ): Set<FunctionFqn> {
-        val changedFunctions = mutableSetOf<FunctionFqn>()
+        fileDiff: FileDiff,
+        moduleName: ModuleName
+    ): Set<ChangedFunction> {
+        val changedFunctions = mutableSetOf<ChangedFunction>()
         val document = getDocument(ktFile) ?: return emptySet()
 
         ktFile.accept(object : KtTreeVisitorVoid() {
@@ -63,7 +100,7 @@ class ChangedFunctionCollector {
                     getFunctionLineRange(function, document)?.let { functionRange ->
                         val isChangedFunction = fileDiff.overlapsWithRange(functionRange)
                         if (isChangedFunction) {
-                            changedFunctions.add(fqn)
+                            changedFunctions.add(ChangedFunction(fqn, moduleName))
                         }
                     }
                 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/FunctionNode.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/FunctionNode.kt
@@ -1,31 +1,37 @@
 package io.github.mikhailhal.sonarkt.common
 
+import java.util.Objects
+
 /**
  * 関数ノード
  *
  * グラフ内の関数を表すドメインモデル。
- * FQNで同一性を判定するため、equals/hashCodeはfqnのみを使用。
+ * マルチモジュール環境では同じFQNが複数モジュールに存在しうるため、
+ * fqn + moduleNameで同一性を判定する。
  *
  * @property fqn 関数の完全修飾名
+ * @property moduleName 関数が属するモジュール名
  * @property isTest @Testアノテーションが付与されているか
  */
 data class FunctionNode(
     val fqn: FunctionFqn,
+    val moduleName: ModuleName,
     val isTest: Boolean
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is FunctionNode) return false
-        return fqn == other.fqn
+        return fqn == other.fqn && moduleName == other.moduleName
     }
 
-    override fun hashCode(): Int = fqn.hashCode()
+    override fun hashCode(): Int = Objects.hash(fqn, moduleName)
 
     companion object {
         /**
          * 検索用のダミーノードを作成
          * isTestの値は検索には影響しない
          */
-        fun forLookup(fqn: FunctionFqn): FunctionNode = FunctionNode(fqn, isTest = false)
+        fun forLookup(fqn: FunctionFqn, moduleName: ModuleName): FunctionNode =
+            FunctionNode(fqn, moduleName, isTest = false)
     }
 }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/Types.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/common/Types.kt
@@ -5,3 +5,9 @@ package io.github.mikhailhal.sonarkt.common
  * 例: "io.github.mikhailhal.sonarkt.Calculator.add"
  */
 typealias FunctionFqn = String
+
+/**
+ * モジュール名
+ * 例: ":core", ":plugin", ":libs:common"
+ */
+typealias ModuleName = String

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolver.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolver.kt
@@ -1,6 +1,8 @@
 package io.github.mikhailhal.sonarkt.processor
 
+import io.github.mikhailhal.sonarkt.collector.ChangedFunction
 import io.github.mikhailhal.sonarkt.common.FunctionFqn
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 
 /**
  * 変更された関数から影響を受けるテストを特定する
@@ -49,13 +51,17 @@ class AffectedTestResolver(
     /**
      * 変更された関数から影響を受けるテストを特定
      *
-     * @param changedFunctions 変更された関数のFQN集合
+     * @param changedFunctions 変更された関数の集合
      * @return 影響を受けるテスト関数のFQN集合
      */
-    fun findAffectedTests(changedFunctions: Set<FunctionFqn>): Set<FunctionFqn> {
+    fun findAffectedTests(changedFunctions: Set<ChangedFunction>): Set<FunctionFqn> {
         val affectedTests = mutableSetOf<FunctionFqn>()
-        val seen = mutableSetOf<FunctionFqn>()
-        val queue = ArrayDeque(changedFunctions)
+        val seen = mutableSetOf<FunctionNode>()
+
+        // ChangedFunctionをFunctionNodeに変換してキューに入れる
+        val queue = ArrayDeque(changedFunctions.map {
+            FunctionNode.forLookup(it.fqn, it.moduleName)
+        })
 
         while (queue.isNotEmpty()) {
             val callee = queue.removeFirst()
@@ -85,7 +91,7 @@ class AffectedTestResolver(
                  * testA が変更された場合、testB も影響を受ける。
                  * よって、テスト関数でも探索を止めずに継続する。
                  */
-                queue.add(caller.fqn)
+                queue.add(caller)
             }
         }
         return affectedTests

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilder.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilder.kt
@@ -1,6 +1,7 @@
 package io.github.mikhailhal.sonarkt.processor
 
 import io.github.mikhailhal.sonarkt.common.FunctionNode
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -23,11 +24,16 @@ class GraphBuilder {
     private val graph = ReverseDependencyGraph()
 
     /**
-     * 複数のKtFileを処理してグラフを構築
+     * 複数モジュールのKtFileを処理してグラフを構築
+     *
+     * @param moduleFiles モジュール名 → KtFileリストのマッピング
+     * @return 構築された逆方向依存グラフ
      */
-    fun build(files: List<KtFile>): ReverseDependencyGraph {
-        for (file in files) {
-            processFile(file)
+    fun build(moduleFiles: Map<ModuleName, List<KtFile>>): ReverseDependencyGraph {
+        for ((moduleName, files) in moduleFiles) {
+            for (file in files) {
+                processFile(file, moduleName)
+            }
         }
         return graph
     }
@@ -35,10 +41,10 @@ class GraphBuilder {
     /**
      * 単一のKtFileを処理
      */
-    private fun processFile(file: KtFile) {
+    private fun processFile(file: KtFile, moduleName: ModuleName) {
         file.accept(object : KtTreeVisitorVoid() {
             override fun visitCallExpression(expression: KtCallExpression) {
-                processCallExpression(expression)
+                processCallExpression(expression, moduleName)
                 super.visitCallExpression(expression)
             }
         })
@@ -47,17 +53,14 @@ class GraphBuilder {
     /**
      * 関数呼び出しを処理してグラフにエッジを追加
      */
-    private fun processCallExpression(expression: KtCallExpression) {
+    private fun processCallExpression(expression: KtCallExpression, moduleName: ModuleName) {
         // 1. caller を特定: この呼び出しを含む関数
-        val callerFunction = expression.getParentOfType<KtNamedFunction>(strict = true)
-        if (callerFunction == null) {
-            // トップレベルの呼び出し（関数外）はスキップ
-            return
-        }
+        val callerFunction = expression.getParentOfType<KtNamedFunction>(strict = true) ?: // トップレベルの呼び出し（関数外）はスキップ
+        return
 
         val callerFqn = callerFunction.fqName?.asString() ?: return
         val callerIsTest = hasTestAnnotation(callerFunction)
-        val callerNode = FunctionNode(callerFqn, callerIsTest)
+        val callerNode = FunctionNode(callerFqn, moduleName, callerIsTest)
 
         // 2. callee を解決: Analysis API で関数シンボルを取得
         analyze(expression) {
@@ -67,8 +70,9 @@ class GraphBuilder {
             if (functionSymbol != null) {
                 val calleeFqn = functionSymbol.callableId?.asSingleFqName()?.asString()
                 if (calleeFqn != null) {
-                    // calleeのisTestはここでは不明だが、検索キーとしてしか使わないのでfalseで良い
-                    val calleeNode = FunctionNode.forLookup(calleeFqn)
+                    // calleeのisTestとmoduleNameはここでは不明だが、検索キーとしてしか使わない
+                    // 同一モジュール内の呼び出しと仮定
+                    val calleeNode = FunctionNode.forLookup(calleeFqn, moduleName)
                     graph.addEdge(callerNode, calleeNode)
                 }
             }

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraph.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraph.kt
@@ -1,6 +1,5 @@
 package io.github.mikhailhal.sonarkt.processor
 
-import io.github.mikhailhal.sonarkt.common.FunctionFqn
 import io.github.mikhailhal.sonarkt.common.FunctionNode
 
 /**
@@ -14,8 +13,8 @@ import io.github.mikhailhal.sonarkt.common.FunctionNode
  *   Calculator.add が testAdd と helperB から呼ばれている場合:
  *   edges[Calculator.add] = {testAdd, helperB}
  *
- * FunctionNodeのequals/hashCodeはfqnのみで判定されるため、
- * 検索時はFunctionNode.forLookup(fqn)で検索用ノードを作成できる。
+ * FunctionNodeのequals/hashCodeはfqn + moduleNameで判定されるため、
+ * マルチモジュール環境でも同じFQNを持つ異なるモジュールの関数を区別できる。
  */
 class ReverseDependencyGraph {
     private val edges: MutableMap<FunctionNode, MutableSet<FunctionNode>> = mutableMapOf()
@@ -26,15 +25,6 @@ class ReverseDependencyGraph {
      */
     fun addEdge(caller: FunctionNode, callee: FunctionNode) {
         edges.getOrPut(callee) { mutableSetOf() }.add(caller)
-    }
-
-    /**
-     * callee を呼んでいる関数（caller）の一覧を取得
-     * FQN文字列で検索可能（FunctionNode.forLookupを内部で使用）
-     */
-    fun getCallers(callee: FunctionFqn): Set<FunctionNode> {
-        val lookupKey = FunctionNode.forLookup(callee)
-        return edges[lookupKey] ?: emptySet()
     }
 
     /**

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/E2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/E2ETest.kt
@@ -2,6 +2,7 @@ package io.github.mikhailhal.sonarkt
 
 import com.intellij.openapi.util.Disposer
 import io.github.mikhailhal.sonarkt.collector.ChangedFunctionCollector
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import io.github.mikhailhal.sonarkt.emitter.AffectedTestEmitter
 import io.github.mikhailhal.sonarkt.processor.AffectedTestResolver
 import io.github.mikhailhal.sonarkt.processor.GraphBuilder
@@ -25,6 +26,10 @@ import kotlin.test.assertTrue
  *            → AffectedTestResolver → AffectedTestEmitter → output
  */
 class E2ETest {
+
+    // テスト用のモジュール名とマッピング
+    private val testModule: ModuleName = "test"
+    private val modulePathMapping = mapOf(testModule to "src/test/resources/sandbox")
 
     @Test
     fun `changing Calculator_add detects testAdd and testHelper`() {
@@ -164,12 +169,13 @@ class E2ETest {
     /**
      * 全パイプラインを実行
      */
-    private fun runPipeline(diff: String, ktFiles: List<KtFile>): String {
+    private fun runPipeline(diff: String, moduleFiles: Map<ModuleName, List<KtFile>>): String {
         // 1. 変更された関数を収集
-        val changedFunctions = ChangedFunctionCollector().collect(diff, ktFiles)
+        val allKtFiles = moduleFiles.values.flatten()
+        val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
 
         // 2. 依存グラフを構築
-        val graph = GraphBuilder().build(ktFiles)
+        val graph = GraphBuilder().build(moduleFiles)
 
         // 3. 影響テストを解決
         val affectedTests = AffectedTestResolver(graph).findAffectedTests(changedFunctions)
@@ -181,7 +187,7 @@ class E2ETest {
     /**
      * sandboxファイルでAnalysis APIセッションを構築して処理を実行
      */
-    private fun withSandboxFiles(block: (List<KtFile>) -> Unit) {
+    private fun withSandboxFiles(block: (Map<ModuleName, List<KtFile>>) -> Unit) {
         val projectDisposable = Disposer.newDisposable("E2ETest")
 
         try {
@@ -190,18 +196,18 @@ class E2ETest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
                 }
             }
 
-            val ktFiles = session.modulesWithFiles
-                .flatMap { it.value }
-                .filterIsInstance<KtFile>()
+            val moduleFiles = session.modulesWithFiles
+                .mapKeys { (kaModule, _) -> kaModule.name }
+                .mapValues { (_, files) -> files.filterIsInstance<KtFile>() }
 
-            block(ktFiles)
+            block(moduleFiles)
         } finally {
             Disposer.dispose(projectDisposable)
         }

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollectorTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollectorTest.kt
@@ -18,6 +18,10 @@ import kotlin.test.assertTrue
  */
 class ChangedFunctionCollectorTest {
 
+    // テスト用のモジュール名とマッピング
+    private val testModule = "test"
+    private val modulePathMapping = mapOf(testModule to "src/test/resources/sandbox")
+
     // === collect ===
 
     @Test
@@ -30,7 +34,7 @@ class ChangedFunctionCollectorTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
@@ -52,9 +56,12 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
 
-            assertEquals(setOf("io.github.mikhailhal.sonarkt.Calculator.add"), changed)
+            assertEquals(
+                setOf(ChangedFunction("io.github.mikhailhal.sonarkt.Calculator.add", testModule)),
+                changed
+            )
         } finally {
             Disposer.dispose(projectDisposable)
         }
@@ -70,7 +77,7 @@ class ChangedFunctionCollectorTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
@@ -94,12 +101,12 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
 
             assertEquals(
                 setOf(
-                    "io.github.mikhailhal.sonarkt.Calculator.add",
-                    "io.github.mikhailhal.sonarkt.Calculator.multiply"
+                    ChangedFunction("io.github.mikhailhal.sonarkt.Calculator.add", testModule),
+                    ChangedFunction("io.github.mikhailhal.sonarkt.Calculator.multiply", testModule)
                 ),
                 changed
             )
@@ -118,7 +125,7 @@ class ChangedFunctionCollectorTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
@@ -140,9 +147,9 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
 
-            assertEquals(setOf("io.github.mikhailhal.sonarkt.helperB"), changed)
+            assertEquals(setOf(ChangedFunction("io.github.mikhailhal.sonarkt.helperB", testModule)), changed)
         } finally {
             Disposer.dispose(projectDisposable)
         }
@@ -160,7 +167,7 @@ class ChangedFunctionCollectorTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
@@ -172,7 +179,7 @@ class ChangedFunctionCollectorTest {
                 .filterIsInstance<KtFile>()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect("", ktFiles)
+            val changed = collector.collect("", ktFiles, modulePathMapping)
 
             assertTrue(changed.isEmpty())
         } finally {
@@ -192,7 +199,7 @@ class ChangedFunctionCollectorTest {
         """.trimIndent()
 
         val collector = ChangedFunctionCollector()
-        val changed = collector.collect(diffOutput, emptyList())
+        val changed = collector.collect(diffOutput, emptyList(), modulePathMapping)
 
         assertTrue(changed.isEmpty())
     }
@@ -207,7 +214,7 @@ class ChangedFunctionCollectorTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
                     })
@@ -229,7 +236,7 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
 
             assertTrue(changed.isEmpty())
         } finally {

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolverTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/AffectedTestResolverTest.kt
@@ -1,5 +1,6 @@
 package io.github.mikhailhal.sonarkt.processor
 
+import io.github.mikhailhal.sonarkt.collector.ChangedFunction
 import io.github.mikhailhal.sonarkt.common.FunctionNode
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -7,9 +8,13 @@ import kotlin.test.assertTrue
 
 class AffectedTestResolverTest {
 
+    // テスト用のデフォルトモジュール名
+    private val testModule = ":test"
+
     // Helper to create nodes
-    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, isTest)
-    private fun testNode(fqn: String) = FunctionNode(fqn, isTest = true)
+    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, testModule, isTest)
+    private fun testNode(fqn: String) = FunctionNode(fqn, testModule, isTest = true)
+    private fun changed(fqn: String) = ChangedFunction(fqn, testModule)
 
     // === Basic detection ===
 
@@ -19,7 +24,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
 
         assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
     }
@@ -32,7 +37,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.CalculatorTest.testHelper"), node("com.example.helperB"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
 
         assertEquals(setOf("com.example.CalculatorTest.testHelper"), affected)
     }
@@ -44,7 +49,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.CalculatorTest.testAddNegative"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
 
         assertEquals(
             setOf(
@@ -63,7 +68,7 @@ class AffectedTestResolverTest {
 
         val resolver = AffectedTestResolver(graph)
         val affected = resolver.findAffectedTests(
-            setOf("com.example.Calculator.add", "com.example.Calculator.multiply")
+            setOf(changed("com.example.Calculator.add"), changed("com.example.Calculator.multiply"))
         )
 
         assertEquals(
@@ -84,7 +89,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.SomeTest.testA"), testNode("com.example.SomeTest.testB"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.changed"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.changed")))
 
         assertEquals(
             setOf(
@@ -113,7 +118,7 @@ class AffectedTestResolverTest {
         val graph = ReverseDependencyGraph()
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.unused"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.unused")))
 
         assertTrue(affected.isEmpty())
     }
@@ -128,7 +133,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.SomeTest.testA"), node("a"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("a"))
+        val affected = resolver.findAffectedTests(setOf(changed("a")))
 
         // Should complete without hanging
         assertEquals(setOf("com.example.SomeTest.testA"), affected)
@@ -142,7 +147,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.Helper.testSomething"), node("com.example.foo"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.foo"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.foo")))
 
         assertEquals(setOf("com.example.Helper.testSomething"), affected)
     }
@@ -153,7 +158,7 @@ class AffectedTestResolverTest {
         graph.addEdge(node("com.example.Helper.doSomething"), node("com.example.foo"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.foo"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.foo")))
 
         assertTrue(affected.isEmpty())
     }
@@ -165,7 +170,7 @@ class AffectedTestResolverTest {
         graph.addEdge(node("com.example.Helper.helper"), node("com.example.Calculator.add"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
 
         // Only the test function should be in result
         assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
@@ -179,7 +184,7 @@ class AffectedTestResolverTest {
         graph.addEdge(testNode("com.example.CalculatorTest.testAdd"), node("com.example.Helper.helper"))
 
         val resolver = AffectedTestResolver(graph)
-        val affected = resolver.findAffectedTests(setOf("com.example.Calculator.add"))
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
 
         assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
     }

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilderTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/GraphBuilderTest.kt
@@ -1,6 +1,7 @@
 package io.github.mikhailhal.sonarkt.processor
 
 import com.intellij.openapi.util.Disposer
+import io.github.mikhailhal.sonarkt.common.FunctionNode
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
@@ -17,6 +18,11 @@ import kotlin.test.assertTrue
  */
 class GraphBuilderTest {
 
+    private val testModule = "test"
+
+    // Helper to create lookup nodes
+    private fun lookup(fqn: String) = FunctionNode.forLookup(fqn, testModule)
+
     @Test
     fun `builds graph from sandbox files`() {
         val projectDisposable = Disposer.newDisposable("GraphBuilderTest")
@@ -27,7 +33,7 @@ class GraphBuilderTest {
                     platform = JvmPlatforms.defaultJvmPlatform
 
                     addModule(buildKtSourceModule {
-                        moduleName = "test"
+                        moduleName = testModule
                         platform = JvmPlatforms.defaultJvmPlatform
                         // sandboxのみを対象にする
                         addSourceRoot(Paths.get("src/test/resources/sandbox"))
@@ -40,15 +46,15 @@ class GraphBuilderTest {
                 .filterIsInstance<KtFile>()
 
             val graphBuilder = GraphBuilder()
-            val graph = graphBuilder.build(ktFiles)
+            val graph = graphBuilder.build(mapOf(testModule to ktFiles))
 
             // Calculator.add は CalculatorTest.testAdd と helperB から呼ばれる
-            val addCallers = graph.getCallers("io.github.mikhailhal.sonarkt.Calculator.add")
+            val addCallers = graph.getCallers(lookup("io.github.mikhailhal.sonarkt.Calculator.add"))
             assertTrue(addCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.CalculatorTest.testAdd" })
             assertTrue(addCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.helperB" })
 
             // helperB は CalculatorTest.testHelper から呼ばれる
-            val helperBCallers = graph.getCallers("io.github.mikhailhal.sonarkt.helperB")
+            val helperBCallers = graph.getCallers(lookup("io.github.mikhailhal.sonarkt.helperB"))
             assertTrue(helperBCallers.any { it.fqn == "io.github.mikhailhal.sonarkt.CalculatorTest.testHelper" })
 
             // @Test annotation detection: testAdd should have isTest = true
@@ -67,7 +73,7 @@ class GraphBuilderTest {
     @Test
     fun `empty file list returns empty graph`() {
         val graphBuilder = GraphBuilder()
-        val graph = graphBuilder.build(emptyList())
+        val graph = graphBuilder.build(emptyMap())
 
         assertTrue(graph.getAllEdges().isEmpty())
     }

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraphTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/processor/ReverseDependencyGraphTest.kt
@@ -7,9 +7,12 @@ import kotlin.test.assertTrue
 
 class ReverseDependencyGraphTest {
 
+    // テスト用のデフォルトモジュール名
+    private val testModule = ":test"
+
     // Helper to create test nodes
-    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, isTest)
-    private fun testNode(fqn: String) = FunctionNode(fqn, isTest = true)
+    private fun node(fqn: String, isTest: Boolean = false) = FunctionNode(fqn, testModule, isTest)
+    private fun testNode(fqn: String) = FunctionNode(fqn, testModule, isTest = true)
 
     // === addEdge / getCallers ===
 
@@ -19,7 +22,7 @@ class ReverseDependencyGraphTest {
 
         graph.addEdge(testNode("testAdd"), node("Calculator.add"))
 
-        val callers = graph.getCallers("Calculator.add")
+        val callers = graph.getCallers(node("Calculator.add"))
         assertEquals(1, callers.size)
         assertTrue(callers.any { it.fqn == "testAdd" })
     }
@@ -31,7 +34,7 @@ class ReverseDependencyGraphTest {
         graph.addEdge(testNode("testAdd"), node("Calculator.add"))
         graph.addEdge(node("helperB"), node("Calculator.add"))
 
-        val callers = graph.getCallers("Calculator.add")
+        val callers = graph.getCallers(node("Calculator.add"))
         assertEquals(2, callers.size)
         assertTrue(callers.any { it.fqn == "testAdd" })
         assertTrue(callers.any { it.fqn == "helperB" })
@@ -44,17 +47,17 @@ class ReverseDependencyGraphTest {
         graph.addEdge(node("main"), node("foo"))
         graph.addEdge(node("main"), node("bar"))
 
-        assertEquals(1, graph.getCallers("foo").size)
-        assertEquals(1, graph.getCallers("bar").size)
-        assertTrue(graph.getCallers("foo").any { it.fqn == "main" })
-        assertTrue(graph.getCallers("bar").any { it.fqn == "main" })
+        assertEquals(1, graph.getCallers(node("foo")).size)
+        assertEquals(1, graph.getCallers(node("bar")).size)
+        assertTrue(graph.getCallers(node("foo")).any { it.fqn == "main" })
+        assertTrue(graph.getCallers(node("bar")).any { it.fqn == "main" })
     }
 
     @Test
     fun `getCallers returns empty set for unknown callee`() {
         val graph = ReverseDependencyGraph()
 
-        val callers = graph.getCallers("unknown.function")
+        val callers = graph.getCallers(node("unknown.function"))
         assertTrue(callers.isEmpty())
     }
 
@@ -65,7 +68,7 @@ class ReverseDependencyGraphTest {
         graph.addEdge(testNode("testAdd"), node("Calculator.add"))
         graph.addEdge(testNode("testAdd"), node("Calculator.add"))
 
-        val callers = graph.getCallers("Calculator.add")
+        val callers = graph.getCallers(node("Calculator.add"))
         assertEquals(1, callers.size)
     }
 
@@ -125,12 +128,36 @@ class ReverseDependencyGraphTest {
         graph.addEdge(testNode("CalculatorTest.testAdd"), node("Calculator.add"))
         graph.addEdge(node("Helper.helperB"), node("Calculator.add"))
 
-        val callers = graph.getCallers("Calculator.add")
+        val callers = graph.getCallers(node("Calculator.add"))
 
         val testCaller = callers.find { it.fqn == "CalculatorTest.testAdd" }
         val helperCaller = callers.find { it.fqn == "Helper.helperB" }
 
         assertEquals(true, testCaller?.isTest)
         assertEquals(false, helperCaller?.isTest)
+    }
+
+    // === Multi-module support ===
+
+    @Test
+    fun `same fqn in different modules are distinct`() {
+        val graph = ReverseDependencyGraph()
+
+        val coreModule = ":core"
+        val pluginModule = ":plugin"
+
+        val coreCallee = FunctionNode("com.example.Util.foo", coreModule, isTest = false)
+        val pluginCallee = FunctionNode("com.example.Util.foo", pluginModule, isTest = false)
+
+        graph.addEdge(testNode("testCore"), coreCallee)
+        graph.addEdge(testNode("testPlugin"), pluginCallee)
+
+        val coreCallers = graph.getCallers(coreCallee)
+        val pluginCallers = graph.getCallers(pluginCallee)
+
+        assertEquals(1, coreCallers.size)
+        assertEquals(1, pluginCallers.size)
+        assertTrue(coreCallers.any { it.fqn == "testCore" })
+        assertTrue(pluginCallers.any { it.fqn == "testPlugin" })
     }
 }

--- a/plugin/src/main/kotlin/io/github/mikhailhal/sonarkt/gradle/AffectedTestsTask.kt
+++ b/plugin/src/main/kotlin/io/github/mikhailhal/sonarkt/gradle/AffectedTestsTask.kt
@@ -1,6 +1,7 @@
 package io.github.mikhailhal.sonarkt.gradle
 
 import io.github.mikhailhal.sonarkt.SonarKt
+import io.github.mikhailhal.sonarkt.common.ModuleName
 import org.gradle.api.DefaultTask
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -12,6 +13,9 @@ import java.nio.file.Path
  * 変更されたコードに影響を受けるテストを検出するタスク
  *
  * Usage: ./gradlew affectedTests
+ *
+ * マルチモジュールプロジェクトにも対応。
+ * 各サブプロジェクトを自動検出してソースルートを収集する。
  */
 abstract class AffectedTestsTask : DefaultTask() {
 
@@ -30,13 +34,15 @@ abstract class AffectedTestsTask : DefaultTask() {
             return
         }
 
-        val sourceRoots = collectSourceRoots()
-        if (sourceRoots.isEmpty()) {
+        val (moduleSourceRoots, modulePathMapping) = collectModuleInfo()
+        if (moduleSourceRoots.isEmpty()) {
             logger.warn("No Kotlin source roots found")
             return
         }
 
-        val output = SonarKt.findAffectedTestsAsString(diff, sourceRoots)
+        logger.lifecycle("Detected modules: ${moduleSourceRoots.keys.joinToString(", ")}")
+
+        val output = SonarKt.findAffectedTestsAsString(diff, moduleSourceRoots, modulePathMapping)
 
         if (output.isNotEmpty()) {
             logger.lifecycle("Affected tests:")
@@ -49,7 +55,7 @@ abstract class AffectedTestsTask : DefaultTask() {
     private fun getGitDiff(baseBranch: String): String {
         return try {
             val process = ProcessBuilder("git", "diff", "--unified=0", "$baseBranch...HEAD")
-                .directory(project.projectDir)
+                .directory(project.rootProject.projectDir)
                 .redirectErrorStream(true)
                 .start()
 
@@ -68,7 +74,37 @@ abstract class AffectedTestsTask : DefaultTask() {
         }
     }
 
-    private fun collectSourceRoots(): List<Path> {
+    /**
+     * マルチモジュール情報を収集
+     *
+     * @return Pair of (moduleSourceRoots, modulePathMapping)
+     */
+    private fun collectModuleInfo(): Pair<Map<ModuleName, List<Path>>, Map<ModuleName, String>> {
+        val moduleSourceRoots = mutableMapOf<ModuleName, List<Path>>()
+        val modulePathMapping = mutableMapOf<ModuleName, String>()
+        val rootDir = project.rootProject.projectDir
+
+        // ルートプロジェクトと全サブプロジェクトを処理
+        val allProjects = listOf(project.rootProject) + project.rootProject.subprojects
+
+        for (proj in allProjects) {
+            val moduleName: ModuleName = proj.path.ifEmpty { ":" }
+            val relativePath = rootDir.toPath().relativize(proj.projectDir.toPath()).toString()
+
+            val sourceRoots = collectSourceRootsForProject(proj.projectDir)
+            if (sourceRoots.isNotEmpty()) {
+                moduleSourceRoots[moduleName] = sourceRoots
+                modulePathMapping[moduleName] = relativePath.ifEmpty { "." }
+            }
+        }
+
+        return Pair(moduleSourceRoots, modulePathMapping)
+    }
+
+    /**
+     * 単一プロジェクトのソースルートを収集
+     */
+    private fun collectSourceRootsForProject(projectDir: java.io.File): List<Path> {
         val roots = mutableListOf<Path>()
 
         val standardPaths = listOf(
@@ -78,7 +114,7 @@ abstract class AffectedTestsTask : DefaultTask() {
             "src/test/java"
         )
         standardPaths.forEach { path ->
-            val dir = project.projectDir.resolve(path)
+            val dir = projectDir.resolve(path)
             if (dir.exists()) {
                 roots.add(dir.toPath())
             }


### PR DESCRIPTION
- Add ModuleName typealias for type clarity
- Create ChangedFunction domain model with fqn + moduleName
- Update FunctionNode equals/hashCode to use both fqn and moduleName
- Update ChangedFunctionCollector to accept modulePathMapping and resolve modules using longest prefix matching
- Update GraphBuilder to accept Map<ModuleName, List<KtFile>>
- Update AffectedTestResolver to accept Set<ChangedFunction>
- Update SonarKt API for multi-module projects
- Update AffectedTestsTask to auto-detect all Gradle subprojects

Closes #5