### PR TITLE
feat: Improve file path matching with proper projectRoot

### DIFF
--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/Main.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/Main.kt
@@ -37,9 +37,10 @@ fun main(args: Array<String>) {
     val projectDisposable = Disposer.newDisposable("sonar-kt")
 
     try {
+        val projectRoot = Paths.get(projectPath).toAbsolutePath()
         val moduleFiles = loadKtFiles(projectPath, projectDisposable)
         val modulePathMapping = mapOf(DEFAULT_MODULE to projectPath)
-        val output = runPipeline(diff, moduleFiles, modulePathMapping)
+        val output = runPipeline(diff, moduleFiles, modulePathMapping, projectRoot)
 
         if (output.isNotEmpty()) {
             println(output)
@@ -100,10 +101,11 @@ private fun loadKtFiles(
 private fun runPipeline(
     diff: String,
     moduleFiles: Map<ModuleName, List<KtFile>>,
-    modulePathMapping: Map<ModuleName, String>
+    modulePathMapping: Map<ModuleName, String>,
+    projectRoot: java.nio.file.Path
 ): String {
     val allKtFiles = moduleFiles.values.flatten()
-    val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
+    val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping, projectRoot)
     val graph = GraphBuilder().build(moduleFiles)
     val affectedTests = AffectedTestResolver(graph).findAffectedTests(changedFunctions)
     return AffectedTestEmitter.emit(affectedTests)

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/SonarKt.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/SonarKt.kt
@@ -35,12 +35,14 @@ object SonarKt {
      * @param diff git diff --unified=0 の出力
      * @param moduleSourceRoots モジュール名 → ソースルートリストのマッピング
      * @param modulePathMapping モジュール名 → モジュールルートパスのマッピング（diff解析用）
+     * @param projectRoot プロジェクトルートの絶対パス
      * @return 影響テストのFQN集合
      */
     fun findAffectedTests(
         diff: String,
         moduleSourceRoots: Map<ModuleName, List<Path>>,
-        modulePathMapping: Map<ModuleName, String>
+        modulePathMapping: Map<ModuleName, String>,
+        projectRoot: Path
     ): Set<String> {
         if (diff.isEmpty() || moduleSourceRoots.isEmpty()) {
             return emptySet()
@@ -56,7 +58,7 @@ object SonarKt {
 
             // ChangedFunctionCollectorは全ファイルをフラットに受け取る
             val allKtFiles = moduleFiles.values.flatten()
-            val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
+            val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping, projectRoot)
 
             val graph = GraphBuilder().build(moduleFiles)
             return AffectedTestResolver(graph).findAffectedTests(changedFunctions)
@@ -71,9 +73,10 @@ object SonarKt {
     fun findAffectedTestsAsString(
         diff: String,
         moduleSourceRoots: Map<ModuleName, List<Path>>,
-        modulePathMapping: Map<ModuleName, String>
+        modulePathMapping: Map<ModuleName, String>,
+        projectRoot: Path
     ): String {
-        val affected = findAffectedTests(diff, moduleSourceRoots, modulePathMapping)
+        val affected = findAffectedTests(diff, moduleSourceRoots, modulePathMapping, projectRoot)
         return AffectedTestEmitter.emit(affected)
     }
 

--- a/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollector.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollector.kt
@@ -6,6 +6,8 @@ import io.github.mikhailhal.sonarkt.common.ModuleName
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
+import java.nio.file.Path
+import java.nio.file.Paths
 
 /**
  * git diffから変更された関数を特定するCollector
@@ -26,12 +28,14 @@ class ChangedFunctionCollector {
      * @param ktFiles 解析対象のKtFileリスト
      * @param modulePathMapping モジュール名 → モジュールルートパスのマッピング
      *                         例: mapOf(":core" to "core", ":plugin" to "plugin")
+     * @param projectRoot プロジェクトルートの絶対パス（相対パス計算に使用）
      * @return 変更された関数の集合
      */
     fun collect(
         diffOutput: String,
         ktFiles: List<KtFile>,
-        modulePathMapping: Map<ModuleName, String>
+        modulePathMapping: Map<ModuleName, String>,
+        projectRoot: Path
     ): Set<ChangedFunction> {
         val fileDiffs = GitDiffParser.parseKotlinFiles(diffOutput)
         val changedFunctions = mutableSetOf<ChangedFunction>()
@@ -39,9 +43,9 @@ class ChangedFunctionCollector {
         if (fileDiffs.isEmpty()) return emptySet()
 
         for (ktFile in ktFiles) {
-            // ファイルパスをリポジトリルートからの相対パスに変換して照合
+            // ファイルパスをプロジェクトルートからの相対パスに変換して照合
             val filePath = ktFile.virtualFile?.path ?: continue
-            val relativePath = extractRelativePath(filePath)
+            val relativePath = extractRelativePath(filePath, projectRoot)
 
             val fileDiff = fileDiffs[relativePath] ?: continue
 
@@ -135,19 +139,20 @@ class ChangedFunctionCollector {
     }
 
     /**
-     * ファイルパスからリポジトリルートからの相対パスを抽出
+     * ファイルパスからプロジェクトルートからの相対パスを計算
      *
-     * TODO: 現在は簡易実装。実際にはプロジェクトルートを基準に計算すべき
-     * 例: /home/user/project/src/main/Foo.kt → src/main/Foo.kt
+     * @param absolutePath ファイルの絶対パス
+     * @param projectRoot プロジェクトルートの絶対パス
+     * @return プロジェクトルートからの相対パス
      */
-    private fun extractRelativePath(absolutePath: String): String {
-        // 簡易実装: src/ または test/ から始まる部分を抽出
-        val srcIndex = absolutePath.indexOf("/src/")
-        if (srcIndex >= 0) {
-            return absolutePath.substring(srcIndex + 1) // "/src/..." → "src/..."
+    private fun extractRelativePath(absolutePath: String, projectRoot: Path): String {
+        return try {
+            val absPath = Paths.get(absolutePath)
+            projectRoot.relativize(absPath).toString()
+        } catch (e: IllegalArgumentException) {
+            // 異なるルートの場合（Windowsのドライブが違うなど）
+            // フォールバック: ファイル名のみ返す
+            absolutePath.substringAfterLast("/")
         }
-
-        // フォールバック: ファイル名のみ返す（完全一致は期待できない）
-        return absolutePath.substringAfterLast("/")
     }
 }

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/E2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/E2ETest.kt
@@ -30,6 +30,7 @@ class E2ETest {
     // テスト用のモジュール名とマッピング
     private val testModule: ModuleName = "test"
     private val modulePathMapping = mapOf(testModule to "src/test/resources/sandbox")
+    private val projectRoot = Paths.get("").toAbsolutePath()
 
     @Test
     fun `changing Calculator_add detects testAdd and testHelper`() {
@@ -172,7 +173,7 @@ class E2ETest {
     private fun runPipeline(diff: String, moduleFiles: Map<ModuleName, List<KtFile>>): String {
         // 1. 変更された関数を収集
         val allKtFiles = moduleFiles.values.flatten()
-        val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping)
+        val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, modulePathMapping, projectRoot)
 
         // 2. 依存グラフを構築
         val graph = GraphBuilder().build(moduleFiles)

--- a/core/src/test/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollectorTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sonarkt/collector/ChangedFunctionCollectorTest.kt
@@ -21,6 +21,7 @@ class ChangedFunctionCollectorTest {
     // テスト用のモジュール名とマッピング
     private val testModule = "test"
     private val modulePathMapping = mapOf(testModule to "src/test/resources/sandbox")
+    private val projectRoot = Paths.get("").toAbsolutePath()
 
     // === collect ===
 
@@ -56,7 +57,7 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping, projectRoot)
 
             assertEquals(
                 setOf(ChangedFunction("io.github.mikhailhal.sonarkt.Calculator.add", testModule)),
@@ -101,7 +102,7 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping, projectRoot)
 
             assertEquals(
                 setOf(
@@ -147,7 +148,7 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping, projectRoot)
 
             assertEquals(setOf(ChangedFunction("io.github.mikhailhal.sonarkt.helperB", testModule)), changed)
         } finally {
@@ -179,7 +180,7 @@ class ChangedFunctionCollectorTest {
                 .filterIsInstance<KtFile>()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect("", ktFiles, modulePathMapping)
+            val changed = collector.collect("", ktFiles, modulePathMapping, projectRoot)
 
             assertTrue(changed.isEmpty())
         } finally {
@@ -199,7 +200,7 @@ class ChangedFunctionCollectorTest {
         """.trimIndent()
 
         val collector = ChangedFunctionCollector()
-        val changed = collector.collect(diffOutput, emptyList(), modulePathMapping)
+        val changed = collector.collect(diffOutput, emptyList(), modulePathMapping, projectRoot)
 
         assertTrue(changed.isEmpty())
     }
@@ -236,7 +237,7 @@ class ChangedFunctionCollectorTest {
             """.trimIndent()
 
             val collector = ChangedFunctionCollector()
-            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping)
+            val changed = collector.collect(diffOutput, ktFiles, modulePathMapping, projectRoot)
 
             assertTrue(changed.isEmpty())
         } finally {

--- a/plugin/src/main/kotlin/io/github/mikhailhal/sonarkt/gradle/AffectedTestsTask.kt
+++ b/plugin/src/main/kotlin/io/github/mikhailhal/sonarkt/gradle/AffectedTestsTask.kt
@@ -42,7 +42,8 @@ abstract class AffectedTestsTask : DefaultTask() {
 
         logger.lifecycle("Detected modules: ${moduleSourceRoots.keys.joinToString(", ")}")
 
-        val output = SonarKt.findAffectedTestsAsString(diff, moduleSourceRoots, modulePathMapping)
+        val projectRoot = project.rootProject.projectDir.toPath()
+        val output = SonarKt.findAffectedTestsAsString(diff, moduleSourceRoots, modulePathMapping, projectRoot)
 
         if (output.isNotEmpty()) {
             logger.lifecycle("Affected tests:")


### PR DESCRIPTION
- Add projectRoot parameter to ChangedFunctionCollector.collect()
- Replace /src/ hardcoded path extraction with Path.relativize()
- Update SonarKt, Main, AffectedTestsTask to pass projectRoot
- Update tests to use Paths.get("").toAbsolutePath() for projectRoot

Closes #4