### PR TITLE
Implement - Add integration test modeled on real Android project structure

### DIFF
--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
@@ -71,6 +71,23 @@ class ViewModelIdiomE2ETest {
         }
     }
 
+    @Ignore // TODO(#27): チェーン付きプロパティ初期化子内の呼び出しがグラフに乗ったら有効化
+    @Test
+    fun `changing loadStream detects testStream via chained property initializer`() {
+        // stateIn/shareIn イディオムの形: val stream = buildStream(repository).stateInLike()
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 21,
+                before = "    fun loadStream(): String = \"stream\"",
+                after = "    fun loadStream(): String = \"stream\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testStream", output)
+        }
+    }
+
     @Ignore // TODO(#28): by lazy デリゲート内の呼び出しがグラフに乗ったら有効化
     @Test
     fun `changing loadConfig detects testConfig via lazy delegate`() {

--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
@@ -1,0 +1,185 @@
+package io.github.mikhailhal.sazanami
+
+import com.intellij.openapi.util.Disposer
+import io.github.mikhailhal.sazanami.collector.ChangedFunctionCollector
+import io.github.mikhailhal.sazanami.common.ModuleName
+import io.github.mikhailhal.sazanami.emitter.AffectedTestEmitter
+import io.github.mikhailhal.sazanami.processor.AffectedTestResolver
+import io.github.mikhailhal.sazanami.processor.GraphBuilder
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
+import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Paths
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Android の ViewModel イディオムを模した E2E テスト (#30)
+ *
+ * 呼び出しが関数本体の外側に置かれるパターンの検出を検証する:
+ * - プロパティ初期化子 (#27)
+ * - by lazy デリゲート / 格納ラムダ / init ブロック (#28)
+ *
+ * fixture 構成:
+ *   vmApp (vmCore に依存)
+ *     AppViewModel: val uiState = buildUiState(repository) などのイディオム
+ *     AppViewModelTest: 各経路を通るテスト
+ *   vmCore
+ *     Repository: 変更対象の関数群 (経路ごとに分離)
+ */
+class ViewModelIdiomE2ETest {
+
+    private val vmCore: ModuleName = "vmCore"
+    private val vmApp: ModuleName = "vmApp"
+    private val pathMapping = mapOf(
+        vmCore to "src/test/resources/sandbox/vmCore",
+        vmApp to "src/test/resources/sandbox/vmApp"
+    )
+    private val projectRoot = Paths.get("").toAbsolutePath()
+
+    @Test
+    fun `changing reload detects testRefresh via ordinary function call`() {
+        // コントロール: 関数本体内の呼び出し連鎖は現行仕様で検出できる
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 19,
+                before = "    fun reload(): String = \"reloaded\"",
+                after = "    fun reload(): String = \"reloaded\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testRefresh", output)
+        }
+    }
+
+    @Ignore // TODO(#27): プロパティ初期化子内の呼び出しがグラフに乗ったら有効化
+    @Test
+    fun `changing load detects testUiState via property initializer`() {
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 15,
+                before = "    fun load(): String = \"data\"",
+                after = "    fun load(): String = \"data\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testUiState", output)
+        }
+    }
+
+    @Ignore // TODO(#28): by lazy デリゲート内の呼び出しがグラフに乗ったら有効化
+    @Test
+    fun `changing loadConfig detects testConfig via lazy delegate`() {
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 16,
+                before = "    fun loadConfig(): String = \"config\"",
+                after = "    fun loadConfig(): String = \"config\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testConfig", output)
+        }
+    }
+
+    @Ignore // TODO(#28): 格納ラムダ内の呼び出しがグラフに乗ったら有効化
+    @Test
+    fun `changing processEvent detects testHandler via stored lambda`() {
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 17,
+                before = "    fun processEvent(): Int = 1",
+                after = "    fun processEvent(): Int = 1 // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testHandler", output)
+        }
+    }
+
+    @Ignore // TODO(#28): init ブロック内の呼び出しがグラフに乗ったら有効化
+    @Test
+    fun `changing warmUp detects testWarm via init block`() {
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 18,
+                before = "    fun warmUp(): Int = 0",
+                after = "    fun warmUp(): Int = 0 // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testWarm", output)
+        }
+    }
+
+    // === Helper functions ===
+
+    /**
+     * Repository.kt の指定行を変更する diff を生成
+     */
+    private fun repositoryDiff(line: Int, before: String, after: String): String = """
+        diff --git a/src/test/resources/sandbox/vmCore/Repository.kt b/src/test/resources/sandbox/vmCore/Repository.kt
+        --- a/src/test/resources/sandbox/vmCore/Repository.kt
+        +++ b/src/test/resources/sandbox/vmCore/Repository.kt
+        @@ -$line +$line @@
+        -$before
+        +$after
+    """.trimIndent()
+
+    /**
+     * 全パイプラインを実行
+     */
+    private fun runPipeline(diff: String, moduleFiles: Map<ModuleName, List<KtFile>>): String {
+        val allKtFiles = moduleFiles.values.flatten()
+        val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, pathMapping, projectRoot)
+
+        val graph = GraphBuilder().build(moduleFiles)
+        val affectedTests = AffectedTestResolver(graph).findAffectedTests(changedFunctions)
+
+        return AffectedTestEmitter.emit(affectedTests)
+    }
+
+    /**
+     * vmCore / vmApp の2モジュール構成で Analysis API セッションを構築
+     * vmApp が vmCore に依存する
+     */
+    private fun withViewModelFixture(block: (Map<ModuleName, List<KtFile>>) -> Unit) {
+        val projectDisposable = Disposer.newDisposable("ViewModelIdiomE2ETest")
+
+        try {
+            val session = buildStandaloneAnalysisAPISession(projectDisposable) {
+                buildKtModuleProvider {
+                    platform = JvmPlatforms.defaultJvmPlatform
+
+                    val core = addModule(buildKtSourceModule {
+                        moduleName = vmCore
+                        this.platform = JvmPlatforms.defaultJvmPlatform
+                        addSourceRoot(Paths.get("src/test/resources/sandbox/vmCore"))
+                    })
+
+                    addModule(buildKtSourceModule {
+                        moduleName = vmApp
+                        this.platform = JvmPlatforms.defaultJvmPlatform
+                        addSourceRoot(Paths.get("src/test/resources/sandbox/vmApp"))
+                        addRegularDependency(core)
+                    })
+                }
+            }
+
+            val moduleFiles = session.modulesWithFiles
+                .mapKeys { (kaModule, _) -> kaModule.name }
+                .mapValues { (_, files) -> files.filterIsInstance<KtFile>() }
+
+            block(moduleFiles)
+        } finally {
+            Disposer.dispose(projectDisposable)
+        }
+    }
+}

--- a/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
@@ -1,0 +1,30 @@
+package io.github.mikhailhal.sazanami.vmapp
+
+import io.github.mikhailhal.sazanami.vmcore.Repository
+
+/**
+ * Android の ViewModel イディオムを模したクラス
+ * 呼び出しが関数本体の外側 (プロパティ初期化子・デリゲート・格納ラムダ・init) に
+ * 置かれるパターンを網羅する
+ */
+class AppViewModel(private val repository: Repository) {
+    // プロパティ初期化子内の呼び出し (Android の uiState イディオム)
+    val uiState: String = buildUiState(repository)
+
+    // by lazy デリゲート内の呼び出し
+    val config: String by lazy { repository.loadConfig() }
+
+    // プロパティに格納されたラムダ内の呼び出し
+    val handler: () -> Int = { repository.processEvent() }
+
+    // init ブロック内の呼び出し
+    var warm: Int = 0
+    init {
+        warm = repository.warmUp()
+    }
+
+    // 通常の関数本体内の呼び出し (現行仕様で検出可能なコントロール)
+    fun refresh(): String = repository.reload()
+}
+
+private fun buildUiState(repository: Repository): String = repository.load()

--- a/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
@@ -25,6 +25,14 @@ class AppViewModel(private val repository: Repository) {
 
     // 通常の関数本体内の呼び出し (現行仕様で検出可能なコントロール)
     fun refresh(): String = repository.reload()
+
+    // stateIn/shareIn イディオムを模したチェーン付きプロパティ初期化子
+    val stream: String = buildStream(repository).stateInLike()
 }
 
 private fun buildUiState(repository: Repository): String = repository.load()
+
+private fun buildStream(repository: Repository): String = repository.loadStream()
+
+// stateIn/shareIn 風のチェーンを作るためのライブラリ非依存な拡張
+private fun <T> T.stateInLike(): T = this

--- a/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
@@ -1,0 +1,39 @@
+package io.github.mikhailhal.sazanami.vmapp
+
+import io.github.mikhailhal.sazanami.vmcore.Repository
+import kotlin.test.Test
+
+/**
+ * AppViewModel のテスト
+ * 各テストは AppViewModel の異なる経路を通って vmCore の Repository に到達する
+ */
+class AppViewModelTest {
+    @Test
+    fun testUiState() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.uiState
+    }
+
+    @Test
+    fun testConfig() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.config
+    }
+
+    @Test
+    fun testHandler() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.handler()
+    }
+
+    @Test
+    fun testWarm() {
+        AppViewModel(Repository())
+    }
+
+    @Test
+    fun testRefresh() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.refresh()
+    }
+}

--- a/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
@@ -36,4 +36,10 @@ class AppViewModelTest {
         val viewModel = AppViewModel(Repository())
         viewModel.refresh()
     }
+
+    @Test
+    fun testStream() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.stream
+    }
 }

--- a/core/src/test/resources/sandbox/vmCore/Repository.kt
+++ b/core/src/test/resources/sandbox/vmCore/Repository.kt
@@ -1,0 +1,20 @@
+package io.github.mikhailhal.sazanami.vmcore
+
+/**
+ * vmCore モジュールのリポジトリ
+ * vmApp モジュールの AppViewModel から様々な経路で呼び出される
+ *
+ * 各関数は検出経路ごとに分離されている:
+ * - load: プロパティ初期化子経由 (#27)
+ * - loadConfig: by lazy デリゲート経由 (#28)
+ * - processEvent: 格納ラムダ経由 (#28)
+ * - warmUp: init ブロック経由 (#28)
+ * - reload: 通常の関数呼び出し経由 (現行仕様で検出可能なコントロール)
+ */
+class Repository {
+    fun load(): String = "data"
+    fun loadConfig(): String = "config"
+    fun processEvent(): Int = 1
+    fun warmUp(): Int = 0
+    fun reload(): String = "reloaded"
+}

--- a/core/src/test/resources/sandbox/vmCore/Repository.kt
+++ b/core/src/test/resources/sandbox/vmCore/Repository.kt
@@ -17,4 +17,6 @@ class Repository {
     fun processEvent(): Int = 1
     fun warmUp(): Int = 0
     fun reload(): String = "reloaded"
+    // loadStream: チェーン付きプロパティ初期化子経由 (#27)
+    fun loadStream(): String = "stream"
 }


### PR DESCRIPTION
Closes #30

## Summary
Adds a cross-module E2E fixture (`vmApp` → `vmCore`) modeling the Android ViewModel idiom, where calls sit outside function bodies. Each `Repository` function is a separate detection path:

| Path | Fixture | Status today |
|---|---|---|
| Ordinary function call (control) | `refresh()` → `reload()` | ✅ detected |
| Property initializer | `val uiState = buildUiState(repository)` | ❌ `@Ignore` → #27 |
| Chained property initializer (stateIn/shareIn shape) | `val stream = buildStream(repository).stateInLike()` | ❌ `@Ignore` → #27 |
| `by lazy` delegate | `val config by lazy { repository.loadConfig() }` | ❌ `@Ignore` → #28 |
| Stored lambda | `val handler = { repository.processEvent() }` | ❌ `@Ignore` → #28 |
| `init` block | `init { warm = repository.warmUp() }` | ❌ `@Ignore` → #28 |

## Verification
- All five idiom tests were run un-ignored and confirmed to fail (the gaps are real), then marked `@Ignore` referencing their fix issues
- The control test passes, proving fixture wiring and cross-module resolution are correct
- Full suite: 86 tests, 0 failures (5 skipped)

Fixing #27/#28 means removing the corresponding `@Ignore` and turning these green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)