### PR TITLE
Implement - Attribute calls inside stored lambdas and property delegates to their enclosing declaration

### DIFF
--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/common/CallableNode.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/common/CallableNode.kt
@@ -7,7 +7,8 @@ import java.util.Objects
  */
 enum class NodeType {
     FUNCTION,
-    PROPERTY
+    PROPERTY,
+    CONSTRUCTOR
 }
 
 /**

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
@@ -8,8 +8,13 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.singleVariableAccessCall
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtClassInitializer
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
@@ -34,9 +39,15 @@ import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
  *     (val uiState = build(...).stateIn(...)) の経路を追跡できる (#27)
  *
  * エッジの張り方:
- *   1. owner = 式を囲む最も近い非ローカル宣言 (関数 or プロパティ)
- *   2. target = Analysis API で解決した呼び出し先関数 / 参照先プロパティ
+ *   1. owner = 式を囲む最も近い非ローカル宣言 (関数 / プロパティ / コンストラクタ)
+ *   2. target = Analysis API で解決した呼び出し先関数 / 参照先プロパティ / コンストラクタ
  *   3. graph.addEdge(owner, target) で登録
+ *
+ * 既知の制限: プロパティ初期化子は構築時にも実行されるが、
+ * <init> → プロパティのエッジは意図的に張っていない。
+ * 「構築するだけで読まない」テストへの影響 (構築時の例外・副作用) は
+ * 参照エッジでは捕捉されない。選択の細かさを優先した判断で、
+ * 保守的モードの導入案は選択厳格度オプションのイシューを参照。
  */
 class CallGraphBuilder {
     private val graph = CallGraph()
@@ -75,6 +86,9 @@ class CallGraphBuilder {
 
     /**
      * 関数呼び出しを処理してグラフにエッジを追加
+     *
+     * コンストラクタ呼び出し (Foo()) は `<クラスFQN>.<init>` ノードへの
+     * エッジとして扱う。
      */
     private fun processCallExpression(expression: KtCallExpression, moduleName: ModuleName) {
         val owner = resolveOwnerNode(expression, moduleName) ?: return
@@ -85,11 +99,20 @@ class CallGraphBuilder {
             val functionSymbol = call?.singleFunctionCallOrNull()?.symbol
 
             if (functionSymbol != null) {
-                val calleeFqn = functionSymbol.callableId?.asSingleFqName()?.asString()
-                if (calleeFqn != null) {
-                    // calleeのisTestとmoduleNameはここでは不明だが、検索キーとしてしか使わない
-                    // 同一モジュール内の呼び出しと仮定
-                    val calleeNode = CallableNode.forLookup(calleeFqn, moduleName)
+                val calleeNode = when (functionSymbol) {
+                    is KaConstructorSymbol ->
+                        functionSymbol.containingClassId?.asSingleFqName()?.asString()?.let { classFqn ->
+                            CallableNode.forLookup("$classFqn.<init>", moduleName, NodeType.CONSTRUCTOR)
+                        }
+
+                    else ->
+                        functionSymbol.callableId?.asSingleFqName()?.asString()?.let { calleeFqn ->
+                            // calleeのisTestとmoduleNameはここでは不明だが、検索キーとしてしか使わない
+                            // 同一モジュール内の呼び出しと仮定
+                            CallableNode.forLookup(calleeFqn, moduleName)
+                        }
+                }
+                if (calleeNode != null) {
                     graph.addEdge(owner, calleeNode)
                 }
             }
@@ -170,6 +193,26 @@ class CallGraphBuilder {
                         return CallableNode(fqn, moduleName, isTest = false, nodeType = NodeType.PROPERTY)
                     }
                     // ローカル変数: FQNを持たないため、外側の宣言へ帰属を続ける
+                }
+
+                /**
+                 * init { warm = repository.warmUp() }  // initブロック → <クラスFQN>.<init>
+                 * constructor(x: Int) { setup(x) }     // secondaryコンストラクタ本体 → 同上
+                 *
+                 * primary/secondary/initブロックを1つの <init> ノードに集約する (#28)
+                 */
+                is KtClassInitializer, is KtConstructor<*> -> {
+                    val classFqn = (current as KtElement)
+                        .getParentOfType<KtClassOrObject>(strict = true)
+                        ?.fqName?.asString()
+                    if (classFqn != null) {
+                        return CallableNode(
+                            "$classFqn.<init>",
+                            moduleName,
+                            isTest = false,
+                            nodeType = NodeType.CONSTRUCTOR
+                        )
+                    }
                 }
             }
             current = current.parent

--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModu
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Paths
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -133,9 +132,11 @@ class ViewModelIdiomE2ETest {
         }
     }
 
-    @Ignore // TODO(#28): init ブロック内の呼び出しがグラフに乗ったら有効化
     @Test
-    fun `changing warmUp detects testWarm via init block`() {
+    fun `changing warmUp detects all constructing tests via init block`() {
+        // init ブロックはインスタンス構築時に必ず実行されるため、
+        // 影響集合は「AppViewModel を構築する全テスト」になる (#28)
+        // warmUp ← <init>(initブロック帰属) ← AppViewModel(...) を呼ぶ全テスト
         withViewModelFixture { moduleFiles ->
             val diff = repositoryDiff(
                 line = 18,
@@ -145,7 +146,18 @@ class ViewModelIdiomE2ETest {
 
             val output = runPipeline(diff, moduleFiles)
 
-            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testWarm", output)
+            assertEquals(
+                """
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testConfig
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testHandler
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testRefresh
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testStream
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testTitle
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testUiState
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testWarm
+                """.trimIndent(),
+                output
+            )
         }
     }
 


### PR DESCRIPTION
Closes #28

## Summary
Completes the remaining scope of #28. The lazy-delegate and stored-lambda paths were already covered by #27's owner generalization (verified by E2E in #34); what remained was init blocks and constructor bodies. This PR adds constructor nodes to the call graph.

## Changes
- `NodeType.CONSTRUCTOR` with FQN convention `<ClassFqn>.<init>` — primary/secondary constructors and init blocks merge into one node (conservative: any constructor path is treated as the same impact surface)
- Owner side: expressions inside `KtClassInitializer` / `KtConstructor` bodies attribute to the `<init>` node
- Callee side: calls resolving to `KaConstructorSymbol` produce edges to `<init>` (constructors lack `callableId`; FQN is built from `containingClassId`)

## Semantics
Init blocks run on **every** construction, so the affected set for an init-block change is every test constructing the class. The E2E expectation changed accordingly (`warmUp` change → all 7 constructing tests, previously asserted 1).

## Design decision (from review)
`<init>` → property-initializer edges are **deliberately not added**: construction-time-only effects (exceptions/side effects) of initializer changes stay unselected, preserving selection granularity for the agent inner loop — CI remains the outer safety net. The conservative variant is proposed as a per-consumer strictness option in #35, documented as a known limitation in `CallGraphBuilder` KDoc.

## Tests
88 tests, 0 failures, **0 skipped** — the last `@Ignore` in the ViewModel-idiom fixture is gone; all six idiom paths from #30 now detect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)