### PR TITLE
Implement - Callable references (::fn) produce no call-graph edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,45 @@ git diff --unified=0 HEAD~1 | ./core/build/install/core/bin/core --project .
 3. **Build Call Graph** — Analyze all source files to build caller→callee relationships
 4. **Reverse Traverse** — Find all test functions that transitively call changed functions
 
+## Kotlin Analysis API: KaSymbol Cheat Sheet
+
+sazanami が扱う `KaSymbol` 階層の地図 (Analysis API 2.1.20 で検証済み)。
+「コード上のどの構文が、どのシンボル型に解決されるか」の対応表:
+
+```
+KaSymbol                                  ← 全シンボルの根
+└── KaDeclarationSymbol                   ← 宣言されたもの全般
+    ├── KaClassifierSymbol                ← 「型」を宣言する側
+    │   └── KaClassSymbol                 ── class Repository の宣言そのもの / 型位置の Repository
+    └── KaCallableSymbol                  ← 呼べる・参照できるもの (sazanami の主戦場)
+        │    共通API: callableId          → FQN取得 (コンストラクタ/ローカルは null)
+        │             allOverriddenSymbols → オーバーライド元を遡る (Collector が使用)
+        │
+        ├── KaFunctionSymbol
+        │   ├── KaNamedFunctionSymbol     ── repository.load() の load / repository::loadRef の loadRef
+        │   ├── KaConstructorSymbol       ── Repository() / ::Repository
+        │   │                                (callableId が null → containingClassId から <init> FQN を組む)
+        │   ├── KaAnonymousFunctionSymbol ── { it + 1 } (ラムダそれ自体)
+        │   └── KaPropertyAccessorSymbol
+        │       ├── KaPropertyGetterSymbol ── val title get() = ... の get()
+        │       └── KaPropertySetterSymbol ── var name set(v) {...} の set()
+        │
+        └── KaVariableSymbol
+            ├── KaPropertySymbol          ── val label = "ready" / viewModel.uiState / repository::label
+            ├── KaLocalVariableSymbol     ── fun f() { val x = 1; x } の x
+            └── KaParameterSymbol
+                └── KaValueParameterSymbol ── fun transform(input: String) の input
+```
+
+sazanami の解決入口と、返ってくるシンボル型の対応:
+
+| 解決入口 | 対象の構文 | 返ってくる型 |
+|---|---|---|
+| `resolveToCall().singleFunctionCallOrNull().symbol` | `load()` / `Repository()` | `KaNamedFunctionSymbol` / `KaConstructorSymbol` |
+| `resolveToCall().singleVariableAccessCall().symbol` | `viewModel.uiState` (参照) | `KaVariableSymbol` のいずれか |
+| `mainReference.resolveToSymbol()` | `::loadRef` / `::Repository` / `::label` | 上記すべての可能性 |
+| `symbol.allOverriddenSymbols` | 実装メソッド → インターフェース | `KaCallableSymbol` |
+
 ## Requirements
 
 - **JDK 21** or later

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
@@ -9,8 +9,11 @@ import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.singleVariableAccessCall
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClassInitializer
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -81,6 +84,11 @@ class CallGraphBuilder {
                 processNameReference(expression, moduleName)
                 super.visitSimpleNameExpression(expression)
             }
+
+            override fun visitCallableReferenceExpression(expression: KtCallableReferenceExpression) {
+                processCallableReference(expression, moduleName)
+                super.visitCallableReferenceExpression(expression)
+            }
         })
     }
 
@@ -147,6 +155,46 @@ class CallGraphBuilder {
                     val propertyNode = CallableNode.forLookup(propertyFqn, moduleName, NodeType.PROPERTY)
                     graph.addEdge(owner, propertyNode)
                 }
+            }
+        }
+    }
+
+    /**
+     * コーラブル参照 (::fn) を処理してグラフにエッジを追加 (#37)
+     *
+     * 例: val refLoader = repository::loadRef   → refLoader → loadRef
+     *     .map(PopulatedNewsResource::asExternalModel) → 囲む宣言 → asExternalModel
+     *     ::Repository (コンストラクタ参照)     → 囲む宣言 → Repository.<init>
+     *     repository::label (プロパティ参照)    → 囲む宣言 → label
+     *
+     * 参照は呼び出しを遅延させるだけで、参照先の変更は参照を実行する側に影響するため、
+     * 保守的に「呼び出しと同じエッジ」として扱う。
+     */
+    private fun processCallableReference(expression: KtCallableReferenceExpression, moduleName: ModuleName) {
+        val owner = resolveOwnerNode(expression, moduleName) ?: return
+
+        analyze(expression) {
+            val symbol = expression.callableReference.mainReference.resolveToSymbol()
+            val targetNode = when (symbol) {
+                is KaConstructorSymbol ->
+                    symbol.containingClassId?.asSingleFqName()?.asString()?.let { classFqn ->
+                        CallableNode.forLookup("$classFqn.<init>", moduleName, NodeType.CONSTRUCTOR)
+                    }
+
+                is KaPropertySymbol ->
+                    symbol.callableId?.asSingleFqName()?.asString()?.let { fqn ->
+                        CallableNode.forLookup(fqn, moduleName, NodeType.PROPERTY)
+                    }
+
+                is KaFunctionSymbol ->
+                    symbol.callableId?.asSingleFqName()?.asString()?.let { fqn ->
+                        CallableNode.forLookup(fqn, moduleName)
+                    }
+
+                else -> null
+            }
+            if (targetNode != null) {
+                graph.addEdge(owner, targetNode)
             }
         }
     }

--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/ViewModelIdiomE2ETest.kt
@@ -13,6 +13,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Paths
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Android の ViewModel イディオムを模した E2E テスト (#30)
@@ -150,6 +151,8 @@ class ViewModelIdiomE2ETest {
                 """
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testConfig
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testHandler
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testMapAll
+                io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testRefLoader
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testRefresh
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testStream
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testTitle
@@ -157,6 +160,59 @@ class ViewModelIdiomE2ETest {
                 io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testWarm
                 """.trimIndent(),
                 output
+            )
+        }
+    }
+
+    @Test
+    fun `changing loadRef detects testRefLoader via stored callable reference`() {
+        // val refLoader: () -> String = repository::loadRef (#37)
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 25,
+                before = "    fun loadRef(): String = \"ref\"",
+                after = "    fun loadRef(): String = \"ref\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testRefLoader", output)
+        }
+    }
+
+    @Test
+    fun `changing transform detects testMapAll via argument-position callable reference`() {
+        // fun mapAll() = listOf("a", "b").map(repository::transform) (#37)
+        withViewModelFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 27,
+                before = "    fun transform(input: String): String = input + \"!\"",
+                after = "    fun transform(input: String): String = input + \"!\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.vmapp.AppViewModelTest.testMapAll", output)
+        }
+    }
+
+    @Test
+    fun `constructor and property references produce call-graph edges`() {
+        // ::Repository と repository::label はcollectorで駆動できない
+        // (コンストラクタ/プロパティ自体の変更検出は別問題) ため、エッジの存在を直接検証する (#37)
+        withViewModelFixture { moduleFiles ->
+            val graph = CallGraphBuilder().build(moduleFiles)
+
+            val initCallers = graph.getCallersByFqn("io.github.mikhailhal.sazanami.vmcore.Repository.<init>")
+            assertTrue(
+                initCallers.any { it.fqn == "io.github.mikhailhal.sazanami.vmapp.AppViewModel.factory" },
+                "factory プロパティの ::Repository 参照がエッジになっていない: $initCallers"
+            )
+
+            val labelCallers = graph.getCallersByFqn("io.github.mikhailhal.sazanami.vmcore.Repository.label")
+            assertTrue(
+                labelCallers.any { it.fqn == "io.github.mikhailhal.sazanami.vmapp.AppViewModel.labelRef" },
+                "labelRef プロパティの repository::label 参照がエッジになっていない: $labelCallers"
             )
         }
     }

--- a/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModel.kt
@@ -32,6 +32,18 @@ class AppViewModel(private val repository: Repository) {
     // カスタム getter 内の呼び出し
     val title: String
         get() = repository.loadTitle()
+
+    // 格納されたメソッド参照 (#37)
+    val refLoader: () -> String = repository::loadRef
+
+    // 引数位置のメソッド参照 (.map(::mapper) イディオム) (#37)
+    fun mapAll(): List<String> = listOf("a", "b").map(repository::transform)
+
+    // コンストラクタ参照 (#37)
+    val factory: () -> Repository = ::Repository
+
+    // プロパティ参照 (#37)
+    val labelRef = repository::label
 }
 
 private fun buildUiState(repository: Repository): String = repository.load()

--- a/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
+++ b/core/src/test/resources/sandbox/vmApp/AppViewModelTest.kt
@@ -48,4 +48,16 @@ class AppViewModelTest {
         val viewModel = AppViewModel(Repository())
         viewModel.title
     }
+
+    @Test
+    fun testRefLoader() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.refLoader()
+    }
+
+    @Test
+    fun testMapAll() {
+        val viewModel = AppViewModel(Repository())
+        viewModel.mapAll()
+    }
 }

--- a/core/src/test/resources/sandbox/vmCore/Repository.kt
+++ b/core/src/test/resources/sandbox/vmCore/Repository.kt
@@ -21,4 +21,10 @@ class Repository {
     fun loadStream(): String = "stream"
     // loadTitle: カスタムgetter経由 (#27)
     fun loadTitle(): String = "title"
+    // loadRef: 格納されたメソッド参照経由 (#37)
+    fun loadRef(): String = "ref"
+    // transform: 引数位置のメソッド参照経由 (#37)
+    fun transform(input: String): String = input + "!"
+    // label: プロパティ参照経由 (#37)
+    val label: String = "ready"
 }


### PR DESCRIPTION
Closes #37

## Summary
Callable references (`::fn`) were neither `KtCallExpression` nor variable accesses, so both existing visitors skipped them — silent false negatives for the idiomatic `.map(Type::mapper)` flow chains (132 occurrences in Now in Android, dominated by data-layer mappers) and callback wiring.

## Changes
- New `visitCallableReferenceExpression` in `CallGraphBuilder`: resolves via `callableReference.mainReference.resolveToSymbol()` and classifies the target —
  - `KaConstructorSymbol` (`::Repository`) → `<ClassFqn>.<init>` node (reuses #28 convention)
  - `KaPropertySymbol` (`repository::label`) → property node
  - other `KaFunctionSymbol` (`repository::loadRef`) → function node
- Owner attribution reuses `resolveOwnerNode`; duplicate edges from the overlapping name-expression visitation collapse in the Set-based graph
- README: verified KaSymbol hierarchy cheat sheet with concrete syntax examples and the resolution entry-point table

## Fixture / E2E (red → green verified)
| Case | Fixture | Test |
|---|---|---|
| Stored reference | `val refLoader = repository::loadRef` | `loadRef` change → `testRefLoader` only |
| Argument position (`.map(::)`) | `fun mapAll() = listOf(...).map(repository::transform)` | `transform` change → `testMapAll` only |
| Constructor / property refs | `::Repository`, `repository::label` | direct graph-edge assertions (not drivable via collector) |

Suite: 91 tests, 0 failures, 0 skipped.

## Real-world verification (Now in Android)
The false negative documented in #37: changing `PopulatedNewsResource.asExternalModel` previously selected only `PopulatedNewsResourceKtTest` (1 test). With this PR: **14 tests**, including `OfflineFirstNewsRepositoryTest` × 11 reached only through `.map(PopulatedNewsResource::asExternalModel)` chains.

Note: `OfflineFirstTopicsRepositoryTest` × 2 are also selected due to the pre-existing FQN-granularity behavior (top-level extensions `PopulatedNewsResource.asExternalModel` / `TopicEntity.asExternalModel` share the FQN `...database.model.asExternalModel` — receiver types are not part of top-level FQNs). Over-selection, conservative direction; accepted as-is for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)