### PR TITLE
Implement - Changing a test function does not select the test itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 ```kotlin
 // build.gradle.kts
 plugins {
-    id("io.github.mikhailhal.sazanami") version "0.2.2"
+    id("io.github.mikhailhal.sazanami") version "0.2.3"
 }
 ```
 

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/collector/ChangedFunction.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/collector/ChangedFunction.kt
@@ -12,8 +12,12 @@ import io.github.mikhailhal.sazanami.common.ModuleName
  *
  * @property fqn 関数の完全修飾名
  * @property moduleName 関数が属するモジュール名
+ * @property isTest 変更された関数自体が@Test付きで、そのまま実行対象になりうるか。
+ *                  テスト関数には呼び出し元が存在しないためBFSでは辿り着けず、
+ *                  リゾルバがこの関数自身を影響テストに含めるために使う (#44)
  */
 data class ChangedFunction(
     val fqn: CallableFqn,
-    val moduleName: ModuleName
+    val moduleName: ModuleName,
+    val isTest: Boolean = false
 )

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/collector/ChangedFunctionCollector.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/collector/ChangedFunctionCollector.kt
@@ -3,6 +3,7 @@ package io.github.mikhailhal.sazanami.collector
 import com.intellij.openapi.editor.Document
 import com.intellij.psi.PsiDocumentManager
 import io.github.mikhailhal.sazanami.common.ModuleName
+import io.github.mikhailhal.sazanami.common.hasTestAnnotation
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -110,7 +111,9 @@ class ChangedFunctionCollector {
                     getFunctionLineRange(function, document)?.let { functionRange ->
                         val isChangedFunction = fileDiff.overlapsWithRange(functionRange)
                         if (isChangedFunction) {
-                            changedFunctions.add(ChangedFunction(fqn, moduleName))
+                            // 変更された関数自体がテストなら、リゾルバが
+                            // その関数自身を影響テストに含められるようフラグを付与する
+                            changedFunctions.add(ChangedFunction(fqn, moduleName, function.hasTestAnnotation()))
                             // オーバーライド元（インターフェース/抽象クラス）のメソッドも追加
                             collectOverriddenMethods(function, moduleName, changedFunctions)
                         }

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/common/TestAnnotations.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/common/TestAnnotations.kt
@@ -1,0 +1,17 @@
+package io.github.mikhailhal.sazanami.common
+
+import org.jetbrains.kotlin.psi.KtNamedFunction
+
+/**
+ * 関数に@Testアノテーションが付与されているかを判定
+ *
+ * 対応アノテーション:
+ * - org.junit.Test (JUnit 4)
+ * - org.junit.jupiter.api.Test (JUnit 5)
+ * - kotlin.test.Test (kotlin-test)
+ */
+fun KtNamedFunction.hasTestAnnotation(): Boolean {
+    return annotationEntries.any { annotation ->
+        annotation.shortName?.asString() == "Test"
+    }
+}

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/AffectedTestResolver.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/AffectedTestResolver.kt
@@ -58,6 +58,15 @@ class AffectedTestResolver(
         val affectedTests = mutableSetOf<CallableFqn>()
         val seen = mutableSetOf<CallableNode>()
 
+        /**
+         * 変更された関数自体がテストの場合、そのテストを影響テストに含める
+         *
+         * BFSは「変更された関数を呼んでいる関数」を辿るため、変更された関数自体は
+         * 判定対象にならない。テスト関数は通常どこからも呼ばれないので、
+         * この判定がないとテストを編集しても何も検出されない。
+         */
+        changedFunctions.filter { it.isTest }.forEach { affectedTests.add(it.fqn) }
+
         // ChangedFunctionをCallableNodeに変換してキューに入れる
         val queue = ArrayDeque(changedFunctions.map {
             CallableNode.forLookup(it.fqn, it.moduleName)

--- a/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
+++ b/core/src/main/kotlin/io/github/mikhailhal/sazanami/processor/CallGraphBuilder.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import io.github.mikhailhal.sazanami.common.CallableNode
 import io.github.mikhailhal.sazanami.common.ModuleName
 import io.github.mikhailhal.sazanami.common.NodeType
+import io.github.mikhailhal.sazanami.common.hasTestAnnotation
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.singleVariableAccessCall
@@ -223,7 +224,7 @@ class CallGraphBuilder {
                 is KtNamedFunction -> {
                     val fqn = current.fqName?.asString()
                     if (fqn != null) {
-                        return CallableNode(fqn, moduleName, hasTestAnnotation(current))
+                        return CallableNode(fqn, moduleName, current.hasTestAnnotation())
                     }
                     // ローカル関数: FQNを持たないため、外側の宣言へ帰属を続ける
                 }
@@ -268,18 +269,4 @@ class CallGraphBuilder {
         return null
     }
 
-    /**
-     * 関数に@Testアノテーションが付与されているかを判定
-     *
-     * 対応アノテーション:
-     * - org.junit.Test (JUnit 4)
-     * - org.junit.jupiter.api.Test (JUnit 5)
-     * - kotlin.test.Test (kotlin-test)
-     */
-    private fun hasTestAnnotation(function: KtNamedFunction): Boolean {
-        return function.annotationEntries.any { annotation ->
-            val shortName = annotation.shortName?.asString()
-            shortName == "Test"
-        }
-    }
 }

--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/E2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/E2ETest.kt
@@ -166,6 +166,26 @@ class E2ETest {
         }
     }
 
+    @Test
+    fun `changing a test function selects the test itself`() {
+        withSandboxFiles { ktFiles ->
+            // CalculatorTest.testAdd の本体を変更したdiff (#44)
+            val diff = """
+                diff --git a/src/test/resources/sandbox/CalculatorTest.kt b/src/test/resources/sandbox/CalculatorTest.kt
+                --- a/src/test/resources/sandbox/CalculatorTest.kt
+                +++ b/src/test/resources/sandbox/CalculatorTest.kt
+                @@ -12 +12 @@
+                -        calc.add(1, 2)
+                +        calc.add(1, 3)
+            """.trimIndent()
+
+            val output = runPipeline(diff, ktFiles)
+
+            // 変更されたテスト自身が影響テストとして返る
+            assertEquals("io.github.mikhailhal.sazanami.CalculatorTest.testAdd", output)
+        }
+    }
+
     // === Cross-module support tests ===
 
     @Test

--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/processor/AffectedTestResolverTest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/processor/AffectedTestResolverTest.kt
@@ -16,6 +16,31 @@ class AffectedTestResolverTest {
     private fun testNode(fqn: String) = CallableNode(fqn, testModule, isTest = true)
     private fun changed(fqn: String) = ChangedFunction(fqn, testModule)
 
+    // === Changed test function selects itself (#44) ===
+
+    @Test
+    fun `changed test function selects itself even without callers`() {
+        // テスト関数には呼び出し元がいないため、変更された関数自体の判定が必要
+        val graph = CallGraph()
+        val resolver = AffectedTestResolver(graph)
+
+        val affected = resolver.findAffectedTests(
+            setOf(ChangedFunction("com.example.CalculatorTest.testAdd", testModule, isTest = true))
+        )
+
+        assertEquals(setOf("com.example.CalculatorTest.testAdd"), affected)
+    }
+
+    @Test
+    fun `changed non-test function does not select itself`() {
+        val graph = CallGraph()
+        val resolver = AffectedTestResolver(graph)
+
+        val affected = resolver.findAffectedTests(setOf(changed("com.example.Calculator.add")))
+
+        assertTrue(affected.isEmpty())
+    }
+
     // === Basic detection ===
 
     @Test

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "io.github.mikhailhal"
-version = "0.2.2"
+version = "0.2.3"
 
 repositories {
     maven("https://redirector.kotlinlang.org/maven/intellij-dependencies")


### PR DESCRIPTION
Closes #44

## Problem
`AffectedTestResolver` only inspected **callers** of changed functions. Test functions have no callers, so editing a test body returned "no affected tests":

```kotlin
@Test
fun testAdd() {
    Calc().add(1, 3)  // ← edited; previously selected nothing
}
```

For the agent inner loop this is a severe (and confusing) false negative — "I edited a test, what should I run?" is one of the most common requests through ariadne.

## Changes
- `ChangedFunction` carries `isTest`; `ChangedFunctionCollector` sets it from the function's `@Test` annotation
- `AffectedTestResolver` adds such changed functions to the result before traversal — the reverse BFS itself is unchanged
- `hasTestAnnotation` extracted to `common/TestAnnotations.kt` as an extension function, shared by the collector and `CallGraphBuilder` (was a private duplicate)

## Tests (red → green verified)
- Resolver unit: a changed test with no callers selects itself; a changed non-test does not select itself (boundary)
- E2E: editing `CalculatorTest.testAdd`'s body through the full pipeline returns `testAdd`

Suite: 94 tests, 0 failures, 0 skipped.

## Version
Bumped to **0.2.3** (README usage sample synced) as requested — patch-level fix.

Branched from `main`; develop will be reconciled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)