### PR TITLE
Implement - Investigate UDF/Flux dispatch patterns (data-flow indirection)

### DIFF
--- a/core/src/test/kotlin/io/github/mikhailhal/sazanami/FluxDispatchE2ETest.kt
+++ b/core/src/test/kotlin/io/github/mikhailhal/sazanami/FluxDispatchE2ETest.kt
@@ -1,0 +1,204 @@
+package io.github.mikhailhal.sazanami
+
+import com.intellij.openapi.util.Disposer
+import io.github.mikhailhal.sazanami.collector.ChangedFunctionCollector
+import io.github.mikhailhal.sazanami.common.ModuleName
+import io.github.mikhailhal.sazanami.emitter.AffectedTestEmitter
+import io.github.mikhailhal.sazanami.processor.AffectedTestResolver
+import io.github.mikhailhal.sazanami.processor.CallGraphBuilder
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
+import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * UDF (Flux/MVI) のディスパッチ配線に対する検出可否を記録するテスト (#38)
+ *
+ * dispatch → collect はデータフローであり静的な呼び出しではないため、
+ * ハンドラへの経路は「collect のラムダがどこに帰属するか」だけで決まる。
+ * 各配線パターンの実際の挙動を、期待値としてここに固定する。
+ */
+class FluxDispatchE2ETest {
+
+    private val fluxModule: ModuleName = "flux"
+    private val pathMapping = mapOf(fluxModule to "src/test/resources/sandbox/flux")
+    private val projectRoot = Paths.get("").toAbsolutePath()
+
+    @Test
+    fun `init-wired store is covered via constructor semantics`() {
+        // collect のラムダが init に帰属するため、
+        // handleRefresh ← <init> ← Store を構築する全テスト の経路が繋がる
+        withFluxFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 9,
+                before = "    fun refreshData(): String = \"refreshed\"",
+                after = "    fun refreshData(): String = \"refreshed\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testInitWired", output)
+        }
+    }
+
+    @Test
+    fun `start-wired store is covered when the test calls start`() {
+        // collect のラムダは start() に帰属する。
+        // テストが start() を呼んでいるため経路が繋がる
+        // (DI/ライフサイクルが start() を呼ぶ構成では繋がらない)
+        withFluxFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 12,
+                before = "    fun startedRefresh(): String = \"started-refresh\"",
+                after = "    fun startedRefresh(): String = \"started-refresh\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testStartWired", output)
+        }
+    }
+
+    @Test
+    fun `map-wired store is covered via the handler reference in the property initializer`() {
+        // ハンドラはメソッド参照でマップに登録される (#37)。
+        // handleMappedRefresh ← handlers プロパティ ← <init> ← 構築するテスト で繋がる
+        withFluxFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 15,
+                before = "    fun mappedRefresh(): String = \"mapped-refresh\"",
+                after = "    fun mappedRefresh(): String = \"mapped-refresh\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testMapWired", output)
+        }
+    }
+
+    // === stateIn / shareIn 系 (Flux の dispatch より実務で多い形) ===
+
+    @Test
+    fun `stateIn chain with map lambda is covered`() {
+        // val uiState = repository.observe().map { it.toUiModel() }.stateIn(...)
+        withFluxFixture { moduleFiles ->
+            val output = runPipeline(flowRepositoryDiff(9, "    fun observe(): FlowLike<String> = FlowLike(\"data\")"), moduleFiles)
+
+            // uiState と combined の2つが observe() を使っている
+            assertEquals(
+                """
+                io.github.mikhailhal.sazanami.flux.StoreTest.testStateFlowCombined
+                io.github.mikhailhal.sazanami.flux.StoreTest.testStateFlowUiState
+                """.trimIndent(),
+                output
+            )
+        }
+    }
+
+    @Test
+    fun `shareIn chain with onEach handler is covered`() {
+        // val events = repository.observeEvents().onEach { handleEvent() }.shareIn(...)
+        withFluxFixture { moduleFiles ->
+            val output = runPipeline(flowRepositoryDiff(14, "    fun onEventHandled(): String = \"handled\""), moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testStateFlowEvents", output)
+        }
+    }
+
+    @Test
+    fun `flatMapLatest nested lambda is covered`() {
+        // val nested = repository.observeTrigger().flatMapLatest { repository.observeNested() }.stateIn(...)
+        withFluxFixture { moduleFiles ->
+            val output = runPipeline(flowRepositoryDiff(19, "    fun observeNested(): FlowLike<String> = FlowLike(\"nested\")"), moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testStateFlowNested", output)
+        }
+    }
+
+    @Test
+    fun `combine lambda is covered`() {
+        // val combined = combineLike(a, b) { a, b -> mergeSources(a, b) }.stateIn(...)
+        withFluxFixture { moduleFiles ->
+            val output = runPipeline(flowRepositoryDiff(22, "    fun merge(a: String, b: String): String = a + b"), moduleFiles)
+
+            assertEquals("io.github.mikhailhal.sazanami.flux.StoreTest.testStateFlowCombined", output)
+        }
+    }
+
+    @Test
+    fun `externally started store is NOT covered - known limitation`() {
+        // 購読開始が DI/ライフサイクル側にある構成では、テストから start() への
+        // 呼び出し経路が存在しないため、ハンドラの変更を検出できない。
+        // 実アプリで最も起こりやすい取りこぼしパターンとして固定する (#38)
+        withFluxFixture { moduleFiles ->
+            val diff = repositoryDiff(
+                line = 18,
+                before = "    fun externalRefresh(): String = \"external-refresh\"",
+                after = "    fun externalRefresh(): String = \"external-refresh\" // modified"
+            )
+
+            val output = runPipeline(diff, moduleFiles)
+
+            assertEquals("", output)
+        }
+    }
+
+    // === Helper functions ===
+
+    private fun flowRepositoryDiff(line: Int, text: String): String = """
+        diff --git a/src/test/resources/sandbox/flux/FlowRepository.kt b/src/test/resources/sandbox/flux/FlowRepository.kt
+        --- a/src/test/resources/sandbox/flux/FlowRepository.kt
+        +++ b/src/test/resources/sandbox/flux/FlowRepository.kt
+        @@ -$line +$line @@
+        -$text
+        +$text // modified
+    """.trimIndent()
+
+    private fun repositoryDiff(line: Int, before: String, after: String): String = """
+        diff --git a/src/test/resources/sandbox/flux/Repository.kt b/src/test/resources/sandbox/flux/Repository.kt
+        --- a/src/test/resources/sandbox/flux/Repository.kt
+        +++ b/src/test/resources/sandbox/flux/Repository.kt
+        @@ -$line +$line @@
+        -$before
+        +$after
+    """.trimIndent()
+
+    private fun runPipeline(diff: String, moduleFiles: Map<ModuleName, List<KtFile>>): String {
+        val allKtFiles = moduleFiles.values.flatten()
+        val changedFunctions = ChangedFunctionCollector().collect(diff, allKtFiles, pathMapping, projectRoot)
+
+        val graph = CallGraphBuilder().build(moduleFiles)
+        val affectedTests = AffectedTestResolver(graph).findAffectedTests(changedFunctions)
+
+        return AffectedTestEmitter.emit(affectedTests)
+    }
+
+    private fun withFluxFixture(block: (Map<ModuleName, List<KtFile>>) -> Unit) {
+        val projectDisposable = Disposer.newDisposable("FluxDispatchE2ETest")
+
+        try {
+            val session = buildStandaloneAnalysisAPISession(projectDisposable) {
+                buildKtModuleProvider {
+                    platform = JvmPlatforms.defaultJvmPlatform
+
+                    addModule(buildKtSourceModule {
+                        moduleName = fluxModule
+                        this.platform = JvmPlatforms.defaultJvmPlatform
+                        addSourceRoot(Paths.get("src/test/resources/sandbox/flux"))
+                    })
+                }
+            }
+
+            val moduleFiles = session.modulesWithFiles
+                .mapKeys { (kaModule, _) -> kaModule.name }
+                .mapValues { (_, files) -> files.filterIsInstance<KtFile>() }
+
+            block(moduleFiles)
+        } finally {
+            Disposer.dispose(projectDisposable)
+        }
+    }
+}

--- a/core/src/test/resources/sandbox/flux/Dispatcher.kt
+++ b/core/src/test/resources/sandbox/flux/Dispatcher.kt
@@ -1,0 +1,25 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * SharedFlow を模した最小のディスパッチャ (ライブラリ非依存)
+ *
+ * dispatch でアクションを投入し、collect で購読する。
+ * 投入と受信は実行時のデータフローで繋がるため、
+ * 静的なコールグラフには「呼び出し」として現れない。
+ */
+class Dispatcher {
+    private val subscribers = mutableListOf<(Action) -> Unit>()
+
+    fun collect(subscriber: (Action) -> Unit) {
+        subscribers.add(subscriber)
+    }
+
+    fun dispatch(action: Action) {
+        subscribers.forEach { it(action) }
+    }
+}
+
+sealed interface Action {
+    data object Refresh : Action
+    data object Load : Action
+}

--- a/core/src/test/resources/sandbox/flux/ExternallyStartedStore.kt
+++ b/core/src/test/resources/sandbox/flux/ExternallyStartedStore.kt
@@ -1,0 +1,36 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * 配線パターン4: 購読の開始を外部 (DI コンテナ / ライフサイクル) が担う Store
+ *
+ * テストは Store を構築して dispatch するだけで、start() を呼ばない。
+ * start() を呼ぶのはプロダクションコード側の AppInitializer であり、
+ * テストからの呼び出し経路が存在しないため、
+ * handleExternalRefresh への到達経路は静的には存在しない。
+ */
+class ExternallyStartedStore(private val dispatcher: Dispatcher, private val repository: Repository) {
+    var state: String = ""
+
+    fun start() {
+        dispatcher.collect { action ->
+            when (action) {
+                is Action.Refresh -> handleExternalRefresh()
+                is Action.Load -> Unit
+            }
+        }
+    }
+
+    private fun handleExternalRefresh() {
+        state = repository.externalRefresh()
+    }
+}
+
+/**
+ * DI コンテナやライフサイクルを模した起動役
+ * (テストからは呼ばれない)
+ */
+class AppInitializer(private val store: ExternallyStartedStore) {
+    fun initialize() {
+        store.start()
+    }
+}

--- a/core/src/test/resources/sandbox/flux/FlowLike.kt
+++ b/core/src/test/resources/sandbox/flux/FlowLike.kt
@@ -1,0 +1,27 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * Flow / StateFlow を模した最小の型 (ライブラリ非依存)
+ *
+ * stateIn / shareIn / map / onEach / flatMapLatest / combine を
+ * 実際の kotlinx.coroutines と同じ形で書けるようにするためのスタブ。
+ */
+class FlowLike<T>(private val value: T) {
+    fun <R> map(transform: (T) -> R): FlowLike<R> = FlowLike(transform(value))
+
+    fun onEach(action: (T) -> Unit): FlowLike<T> {
+        action(value)
+        return this
+    }
+
+    fun <R> flatMapLatest(transform: (T) -> FlowLike<R>): FlowLike<R> = transform(value)
+
+    fun stateIn(scope: Any): FlowLike<T> = this
+
+    fun shareIn(scope: Any): FlowLike<T> = this
+
+    fun get(): T = value
+}
+
+fun <A, B, R> combineLike(a: FlowLike<A>, b: FlowLike<B>, transform: (A, B) -> R): FlowLike<R> =
+    FlowLike(transform(a.get(), b.get()))

--- a/core/src/test/resources/sandbox/flux/FlowRepository.kt
+++ b/core/src/test/resources/sandbox/flux/FlowRepository.kt
@@ -1,0 +1,23 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * stateIn/shareIn 経路の検出を測るための末端処理
+ * 経路ごとに関数を分離している
+ */
+class FlowRepository {
+    // map ラムダ経由 (stateIn)
+    fun observe(): FlowLike<String> = FlowLike("data")
+
+    // onEach ラムダ経由 (shareIn)
+    fun observeEvents(): FlowLike<String> = FlowLike("event")
+
+    fun onEventHandled(): String = "handled"
+
+    // flatMapLatest のネストしたラムダ経由
+    fun observeTrigger(): FlowLike<String> = FlowLike("trigger")
+
+    fun observeNested(): FlowLike<String> = FlowLike("nested")
+
+    // combine のラムダ経由
+    fun merge(a: String, b: String): String = a + b
+}

--- a/core/src/test/resources/sandbox/flux/InitWiredStore.kt
+++ b/core/src/test/resources/sandbox/flux/InitWiredStore.kt
@@ -1,0 +1,25 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * 配線パターン1: init ブロック内で collect する Store
+ *
+ * dispatch → collect はデータフローなのでエッジにならないが、
+ * collect のラムダは init に帰属するため
+ * handleRefresh ← <init> ← Store を構築するテスト の経路が繋がるはず (#28 の構築セマンティクス)
+ */
+class InitWiredStore(dispatcher: Dispatcher, private val repository: Repository) {
+    var state: String = ""
+
+    init {
+        dispatcher.collect { action ->
+            when (action) {
+                is Action.Refresh -> handleRefresh()
+                is Action.Load -> Unit
+            }
+        }
+    }
+
+    private fun handleRefresh() {
+        state = repository.refreshData()
+    }
+}

--- a/core/src/test/resources/sandbox/flux/MapWiredStore.kt
+++ b/core/src/test/resources/sandbox/flux/MapWiredStore.kt
@@ -1,0 +1,24 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * 配線パターン3: ハンドラをマップに登録するディスパッチ
+ *
+ * ハンドラはメソッド参照としてマップに格納される (#37 でエッジになる)。
+ * ただしマップから取り出して呼ぶ側は動的なので、
+ * 「登録」の経路が追えるかどうかが検出可否を決める。
+ */
+class MapWiredStore(private val repository: Repository) {
+    var state: String = ""
+
+    private val handlers: Map<String, () -> Unit> = mapOf(
+        "refresh" to ::handleMappedRefresh
+    )
+
+    fun handle(key: String) {
+        handlers[key]?.invoke()
+    }
+
+    private fun handleMappedRefresh() {
+        state = repository.mappedRefresh()
+    }
+}

--- a/core/src/test/resources/sandbox/flux/Repository.kt
+++ b/core/src/test/resources/sandbox/flux/Repository.kt
@@ -1,0 +1,19 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * 各ハンドラが呼ぶ末端の処理
+ * 検出経路ごとに関数を分離している
+ */
+class Repository {
+    // initブロックで購読する Store 経由
+    fun refreshData(): String = "refreshed"
+
+    // 外部から start() で購読する Store 経由
+    fun startedRefresh(): String = "started-refresh"
+
+    // マップ駆動ディスパッチの Store 経由
+    fun mappedRefresh(): String = "mapped-refresh"
+
+    // 外部 (DI/ライフサイクル) が購読開始する Store 経由
+    fun externalRefresh(): String = "external-refresh"
+}

--- a/core/src/test/resources/sandbox/flux/StartWiredStore.kt
+++ b/core/src/test/resources/sandbox/flux/StartWiredStore.kt
@@ -1,0 +1,25 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * 配線パターン2: 外部から start() を呼んで購読する Store
+ *
+ * collect のラムダは start() に帰属する。
+ * テストが start() を呼んでいれば handleRefresh ← start ← テスト が繋がるが、
+ * DI コンテナやライフサイクルが start() を呼ぶ構成ではテストからの経路が消える。
+ */
+class StartWiredStore(private val dispatcher: Dispatcher, private val repository: Repository) {
+    var state: String = ""
+
+    fun start() {
+        dispatcher.collect { action ->
+            when (action) {
+                is Action.Refresh -> handleStartedRefresh()
+                is Action.Load -> Unit
+            }
+        }
+    }
+
+    private fun handleStartedRefresh() {
+        state = repository.startedRefresh()
+    }
+}

--- a/core/src/test/resources/sandbox/flux/StateFlowStore.kt
+++ b/core/src/test/resources/sandbox/flux/StateFlowStore.kt
@@ -1,0 +1,40 @@
+package io.github.mikhailhal.sazanami.flux
+
+/**
+ * stateIn / shareIn を使う ViewModel/Store の形
+ *
+ * Flux の dispatch とは異なり、プロパティ初期化子のチェーン内で
+ * プロジェクト関数を呼ぶ。検出経路は「初期化子内の呼び出しがプロパティに帰属するか」で決まる。
+ */
+class StateFlowStore(private val repository: FlowRepository) {
+
+    // stateIn: チェーン内の map ラムダでプロジェクト関数を呼ぶ
+    val uiState: FlowLike<String> = repository.observe()
+        .map { it.toUiModel() }
+        .stateIn(this)
+
+    // shareIn: onEach で副作用ハンドラを呼ぶ (Flux と state flow の中間形)
+    val events: FlowLike<String> = repository.observeEvents()
+        .onEach { handleEvent() }
+        .shareIn(this)
+
+    // flatMapLatest: ネストしたラムダ内でプロジェクト関数を呼ぶ
+    val nested: FlowLike<String> = repository.observeTrigger()
+        .flatMapLatest { repository.observeNested() }
+        .stateIn(this)
+
+    // combine: 複数ソースを束ねるラムダ内でプロジェクト関数を呼ぶ
+    val combined: FlowLike<String> = combineLike(
+        repository.observe(),
+        repository.observeEvents()
+    ) { a, b -> mergeSources(a, b) }
+        .stateIn(this)
+
+    private fun handleEvent() {
+        repository.onEventHandled()
+    }
+
+    private fun mergeSources(a: String, b: String): String = repository.merge(a, b)
+}
+
+private fun String.toUiModel(): String = "ui:$this"

--- a/core/src/test/resources/sandbox/flux/StoreTest.kt
+++ b/core/src/test/resources/sandbox/flux/StoreTest.kt
@@ -1,0 +1,64 @@
+package io.github.mikhailhal.sazanami.flux
+
+import kotlin.test.Test
+
+/**
+ * 各 Store を dispatch 経由で駆動するテスト
+ * 実際の Flux/MVI のテストと同じく、テストは dispatch しか呼ばない
+ */
+class StoreTest {
+
+    @Test
+    fun testInitWired() {
+        val dispatcher = Dispatcher()
+        InitWiredStore(dispatcher, Repository())
+        dispatcher.dispatch(Action.Refresh)
+    }
+
+    @Test
+    fun testStartWired() {
+        val dispatcher = Dispatcher()
+        val store = StartWiredStore(dispatcher, Repository())
+        store.start()
+        dispatcher.dispatch(Action.Refresh)
+    }
+
+    @Test
+    fun testMapWired() {
+        val store = MapWiredStore(Repository())
+        store.handle("refresh")
+    }
+
+    @Test
+    fun testStateFlowUiState() {
+        val store = StateFlowStore(FlowRepository())
+        store.uiState
+    }
+
+    @Test
+    fun testStateFlowEvents() {
+        val store = StateFlowStore(FlowRepository())
+        store.events
+    }
+
+    @Test
+    fun testStateFlowNested() {
+        val store = StateFlowStore(FlowRepository())
+        store.nested
+    }
+
+    @Test
+    fun testStateFlowCombined() {
+        val store = StateFlowStore(FlowRepository())
+        store.combined
+    }
+
+    @Test
+    fun testExternallyStarted() {
+        // 実アプリと同じく、購読開始は DI/ライフサイクル側の責務なので
+        // テストは構築して dispatch するだけ
+        val dispatcher = Dispatcher()
+        ExternallyStartedStore(dispatcher, Repository())
+        dispatcher.dispatch(Action.Refresh)
+    }
+}


### PR DESCRIPTION
Closes #38

## Summary
Investigation issue: measure how affected-test selection behaves on UDF architectures, where tests reach handlers through runtime data flow rather than calls. Adds dependency-free fixtures that pin the actual behavior of every common wiring shape, so this area is regression-guarded instead of folklore.

## Findings

**Flux (imperative dispatch)** — `dispatch → collect` is never an edge; what decides coverage is where the collect lambda attributes:

| Wiring | Detected | Carrier |
|---|---|---|
| `init { dispatcher.collect { ... } }` | ✅ | lambda attributes to `<init>` → constructing tests (#28) |
| `fun start()` called by the test | ✅ | lambda attributes to `start()` → test calls it |
| Handler map `mapOf("k" to ::handleX)` | ✅ | callable reference (#37) → property initializer → `<init>` |
| `fun start()` called by DI/lifecycle | ❌ | no path from the test to `start()` — pinned as expected-empty |

**stateIn / shareIn** — all covered, with exact (not coarse) selection: `map`, `onEach`, `flatMapLatest`, `combine`. These chains contain no data-flow break, so #27's attribution handles them directly.

## Files
- `sandbox/flux/`: `Dispatcher` + sealed `Action`, four stores (init / start / map-wired / externally-started), `FlowLike` stub + `StateFlowStore`, `StoreTest`
- `FluxDispatchE2ETest`: 8 assertions covering the table above

Suite: 102 tests, 0 failures, 0 skipped.

## Docs
The conservative-detour explanation and the DI-started gap are recorded in the issue thread; ariadne's README is updated separately with the user-facing limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)